### PR TITLE
[STLND-1968] Version 0.1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,12 +62,12 @@ This will:
 * Connect to the MQTT sink securely.
 
 ### Using Username/Password Authentication
-For scenarios requiring simple username/password authentication, use `configure_dev_username_password_mqtt_lifo_sdk`:
+For scenarios requiring simple username/password authentication, use `configure_dev_basic_mqtt_lifo_sdk`:
 ```python
-from stellanow_sdk_python.configure_sdk import configure_dev_username_password_mqtt_lifo_sdk
+from stellanow_sdk_python.configure_sdk import configure_dev_basic_mqtt_lifo_sdk
 
 async def main():
-    sdk = configure_dev_username_password_mqtt_lifo_sdk()
+    sdk = configure_dev_basic_mqtt_lifo_sdk()
     await sdk.start()
 ```
 
@@ -76,7 +76,7 @@ This will:
 - Connect to the MQTT sink with the specified transport and TLS settings.
 
 ### Using No Authentication
-For local development or scenarios where authentication is not required, use configure_local_nanomq_username_password_mqtt_fifo_sdk or configure_prod_none_mqtt_fifo_sdk:
+For local development or scenarios where authentication is not required, use configure_local_nanomq_basic_mqtt_fifo_sdk or configure_prod_none_mqtt_fifo_sdk:
 
 ```python
 from stellanow_sdk_python.configure_sdk import configure_prod_none_mqtt_fifo_sdk

--- a/README.md
+++ b/README.md
@@ -107,37 +107,88 @@ This script is the main entry point for our demonstration. The main function doe
 - Finally, it disconnects from StellaNow.
 ```python
 import asyncio
+import sys
 from stellanow_sdk_python.configure_sdk import configure_dev_oidc_mqtt_fifo_sdk
-from stellanow_sdk_python_demo.models.user_details_message import UserDetailsMessage, PhoneNumberModel
+from stellanow_sdk_python_demo.messages.models.phone_number_model import PhoneNumberModel
+from stellanow_sdk_python_demo.messages.user_details_update_message import UserDetailsUpdateMessage
 from loguru import logger
 
 async def main():
-    # Establish connection
+    """Main entry point for the StellaNow SDK demo."""
     sdk = configure_dev_oidc_mqtt_fifo_sdk()
-    await sdk.start()
+    shutdown_event = asyncio.Event()  # Event to signal shutdown
 
-    logger.info("Press Ctrl+C to stop the application!")
+    try:
+        await sdk.start()
+        for i in range(10):
+            message = UserDetailsUpdateMessage(
+                patron="12345", user_id=f"user_{i}", phone_number=PhoneNumberModel(country_code=44, number=753594 + i)
+            )
+            logger.info(f"Sending message {i + 1}...")
+            await sdk.send_message(message)
+            await asyncio.sleep(2)
+        logger.info("Initial messages sent. Keeping SDK alive...")
+        await shutdown_event.wait()  # Wait indefinitely until shutdown
     
-    # Ensure connection is established
-    await asyncio.sleep(5)
+    except KeyboardInterrupt:
+        logger.warning("Received Ctrl+C, shutting down gracefully...")
+        shutdown_event.set()  # Signal shutdown
+        await sdk.stop()
+    except Exception as e:
+        logger.error(f"Unexpected error occurred: {e}")
+        await sdk.stop()
+        sys.exit(1)
 
-    uuid = "user_12345"
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+### Setting the Message Origin Timestamp
+
+The `message_origin_date_utc` field in a `StellaNowMessageBase`-derived message specifies the UTC timestamp when the message was created. This field is optional but highly recommended for accurate event tracking and auditing in the StellaNow Platform. The timestamp must be in ISO 8601 format with microseconds and a `Z` suffix (e.g., `2025-04-25T12:34:56.789012Z`) when serialized.
+
+#### Requirements
+- **Type**: Python `datetime` object or ISO 8601 string.
+- **Format**: If provided as a string, it must include microseconds and end with `Z` (e.g., `2025-04-25T12:34:56.789012Z`).
+- **Timezone**: Must represent UTC time. Non-UTC `datetime` objects will raise a validation error.
+- **Validation**: The SDK validates the timestamp to ensure it meets these requirements. Invalid formats will raise a `ValueError`.
+
+#### Setting `message_origin_date_utc`
+Set `message_origin_date_utc` after creating a message by assigning a `datetime` object or a valid ISO 8601 string to the `message_origin_date_utc` property. If not set, the field remains `None` in the message object, but the SDK automatically assigns the current UTC time when the message is wrapped in a `StellaNowMessageWrapper` (e.g., during `sdk.send_message`).
+```python
+import asyncio
+import sys
+from stellanow_sdk_python.configure_sdk import configure_dev_oidc_mqtt_fifo_sdk
+from stellanow_sdk_python_demo.messages.models.phone_number_model import PhoneNumberModel
+from stellanow_sdk_python_demo.messages.user_details_update_message import UserDetailsUpdateMessage
+from loguru import logger
+
+async def main():
+    """Main entry point for the StellaNow SDK demo."""
+    sdk = configure_dev_oidc_mqtt_fifo_sdk()
+    shutdown_event = asyncio.Event()  # Event to signal shutdown
+
+    try:
+        await sdk.start()
+        for i in range(10):
+            message = UserDetailsUpdateMessage(
+                patron="12345", user_id=f"user_{i}", phone_number=PhoneNumberModel(country_code=44, number=753594 + i)
+            )
+            message.message_origin_date_utc = "2025-04-25T12:34:56.789012Z"
+            logger.info(f"Sending message {i + 1}...")
+            await sdk.send_message(message)
+            await asyncio.sleep(2)
+        logger.info("Initial messages sent. Keeping SDK alive...")
+        await shutdown_event.wait()  # Wait indefinitely until shutdown
     
-    # Create and send a message
-    message = UserDetailsMessage(
-        patron_entity_id=uuid,
-        user_id=uuid,
-        phone_number=PhoneNumberModel(country_code=44, number=753594)
-    )
-    
-    await sdk.send_message(message)
-    logger.info("New Message Queued")
-    
-    # Delay to observe
-    await asyncio.sleep(1)
-    
-    # Disconnect and terminate
-    await sdk.stop()
+    except KeyboardInterrupt:
+        logger.warning("Received Ctrl+C, shutting down gracefully...")
+        shutdown_event.set()  # Signal shutdown
+        await sdk.stop()
+    except Exception as e:
+        logger.error(f"Unexpected error occurred: {e}")
+        await sdk.stop()
+        sys.exit(1)
 
 if __name__ == "__main__":
     asyncio.run(main())
@@ -161,10 +212,8 @@ Messages in StellaNowSDK are wrapped in a StellaNowEventWrapper, and each specif
 
 ```python
 from pydantic import Field
-
+from stellanow_sdk_python_demo.messages.models.phone_number_model import PhoneNumberModel
 from stellanow_sdk_python.messages.message import Entity, StellaNowMessageBase
-
-from .models.phone_number_model import PhoneNumberModel
 
 
 class UserDetailsUpdateMessage(StellaNowMessageBase):

--- a/poetry.lock
+++ b/poetry.lock
@@ -48,14 +48,14 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "astroid"
-version = "3.3.8"
+version = "3.3.9"
 description = "An abstract syntax tree for Python with inference support."
 optional = false
 python-versions = ">=3.9.0"
 groups = ["dev"]
 files = [
-    {file = "astroid-3.3.8-py3-none-any.whl", hash = "sha256:187ccc0c248bfbba564826c26f070494f7bc964fd286b6d9fff4420e55de828c"},
-    {file = "astroid-3.3.8.tar.gz", hash = "sha256:a88c7994f914a4ea8572fac479459f4955eeccc877be3f2d959a33273b0cf40b"},
+    {file = "astroid-3.3.9-py3-none-any.whl", hash = "sha256:d05bfd0acba96a7bd43e222828b7d9bc1e138aaeb0649707908d3702a9831248"},
+    {file = "astroid-3.3.9.tar.gz", hash = "sha256:622cc8e3048684aa42c820d9d218978021c3c3d174fb03a9f0d615921744f550"},
 ]
 
 [[package]]
@@ -118,14 +118,14 @@ pycodestyle = ">=2.12.0"
 
 [[package]]
 name = "beautifulsoup4"
-version = "4.13.3"
+version = "4.13.4"
 description = "Screen-scraping library"
 optional = false
 python-versions = ">=3.7.0"
 groups = ["main"]
 files = [
-    {file = "beautifulsoup4-4.13.3-py3-none-any.whl", hash = "sha256:99045d7d3f08f91f0d656bc9b7efbae189426cd913d830294a15eefa0ea4df16"},
-    {file = "beautifulsoup4-4.13.3.tar.gz", hash = "sha256:1bd32405dacc920b42b83ba01644747ed77456a65760e285fbc47633ceddaf8b"},
+    {file = "beautifulsoup4-4.13.4-py3-none-any.whl", hash = "sha256:9bbbb14bfde9d79f38b8cd5f8c7c85f4b8f2523190ebed90e950a8dea4cb1c4b"},
+    {file = "beautifulsoup4-4.13.4.tar.gz", hash = "sha256:dbb3c4e1ceae6aefebdaf2423247260cd062430a410e38c66f2baa50a8437195"},
 ]
 
 [package.dependencies]
@@ -467,14 +467,14 @@ test-randomorder = ["pytest-randomly"]
 
 [[package]]
 name = "decorator"
-version = "5.1.1"
+version = "5.2.1"
 description = "Decorators for Humans"
 optional = false
-python-versions = ">=3.5"
+python-versions = ">=3.8"
 groups = ["dev"]
 files = [
-    {file = "decorator-5.1.1-py3-none-any.whl", hash = "sha256:b8c3f85900b9dc423225913c5aace94729fe1fa9763b38939a95226f02d37186"},
-    {file = "decorator-5.1.1.tar.gz", hash = "sha256:637996211036b6385ef91435e4fae22989472f9d571faba8927ba8253acbc330"},
+    {file = "decorator-5.2.1-py3-none-any.whl", hash = "sha256:d316bb415a2d9e2d2b3abcc4084c6502fc09240e292cd76a76afc106a1c8e04a"},
+    {file = "decorator-5.2.1.tar.gz", hash = "sha256:65f266143752f734b0a7cc83c46f4618af75b8c5911b00ccb61d0ac9b6da0360"},
 ]
 
 [[package]]
@@ -494,14 +494,14 @@ packaging = "*"
 
 [[package]]
 name = "dill"
-version = "0.3.9"
+version = "0.4.0"
 description = "serialize all of Python"
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
 files = [
-    {file = "dill-0.3.9-py3-none-any.whl", hash = "sha256:468dff3b89520b474c0397703366b7b95eebe6303f108adf9b19da1f702be87a"},
-    {file = "dill-0.3.9.tar.gz", hash = "sha256:81aa267dddf68cbfe8029c42ca9ec6a4ab3b22371d1c450abc54422577b4512c"},
+    {file = "dill-0.4.0-py3-none-any.whl", hash = "sha256:44f54bf6412c2c8464c14e8243eb163690a9800dbe2c367330883b19c7561049"},
+    {file = "dill-0.4.0.tar.gz", hash = "sha256:0633f1d2df477324f53a895b02c901fb961bdbf65a17122586ea7019292cbcf0"},
 ]
 
 [package.extras]
@@ -525,31 +525,31 @@ tests = ["asttokens (>=2.1.0)", "coverage", "coverage-enable-subprocess", "ipyth
 
 [[package]]
 name = "h11"
-version = "0.14.0"
+version = "0.16.0"
 description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "h11-0.14.0-py3-none-any.whl", hash = "sha256:e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761"},
-    {file = "h11-0.14.0.tar.gz", hash = "sha256:8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d"},
+    {file = "h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86"},
+    {file = "h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1"},
 ]
 
 [[package]]
 name = "httpcore"
-version = "1.0.7"
+version = "1.0.9"
 description = "A minimal low-level HTTP client."
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "httpcore-1.0.7-py3-none-any.whl", hash = "sha256:a3fff8f43dc260d5bd363d9f9cf1830fa3a458b332856f34282de498ed420edd"},
-    {file = "httpcore-1.0.7.tar.gz", hash = "sha256:8551cb62a169ec7162ac7be8d4817d561f60e08eaa485234898414bb5a8a0b4c"},
+    {file = "httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55"},
+    {file = "httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8"},
 ]
 
 [package.dependencies]
 certifi = "*"
-h11 = ">=0.13,<0.15"
+h11 = ">=0.16"
 
 [package.extras]
 asyncio = ["anyio (>=4.0,<5.0)"]
@@ -599,26 +599,26 @@ all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2
 
 [[package]]
 name = "iniconfig"
-version = "2.0.0"
+version = "2.1.0"
 description = "brain-dead simple config-ini parsing"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 groups = ["dev"]
 files = [
-    {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
-    {file = "iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
+    {file = "iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760"},
+    {file = "iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7"},
 ]
 
 [[package]]
 name = "ipython"
-version = "8.32.0"
+version = "8.35.0"
 description = "IPython: Productive Interactive Computing"
 optional = false
 python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "ipython-8.32.0-py3-none-any.whl", hash = "sha256:cae85b0c61eff1fc48b0a8002de5958b6528fa9c8defb1894da63f42613708aa"},
-    {file = "ipython-8.32.0.tar.gz", hash = "sha256:be2c91895b0b9ea7ba49d33b23e2040c352b33eb6a519cca7ce6e0c743444251"},
+    {file = "ipython-8.35.0-py3-none-any.whl", hash = "sha256:e6b7470468ba6f1f0a7b116bb688a3ece2f13e2f94138e508201fad677a788ba"},
+    {file = "ipython-8.35.0.tar.gz", hash = "sha256:d200b7d93c3f5883fc36ab9ce28a18249c7706e51347681f80a0aef9895f2520"},
 ]
 
 [package.dependencies]
@@ -645,7 +645,7 @@ notebook = ["ipywidgets", "notebook"]
 parallel = ["ipyparallel"]
 qtconsole = ["qtconsole"]
 test = ["packaging", "pickleshare", "pytest", "pytest-asyncio (<0.22)", "testpath"]
-test-extra = ["curio", "ipython[test]", "matplotlib (!=3.2.0)", "nbformat", "numpy (>=1.23)", "pandas", "trio"]
+test-extra = ["curio", "ipython[test]", "jupyter_ai", "matplotlib (!=3.2.0)", "nbformat", "numpy (>=1.23)", "pandas", "trio"]
 
 [[package]]
 name = "isort"
@@ -799,14 +799,14 @@ reports = ["lxml"]
 
 [[package]]
 name = "mypy-extensions"
-version = "1.0.0"
+version = "1.1.0"
 description = "Type system extensions for programs checked with the mypy type checker."
 optional = false
-python-versions = ">=3.5"
+python-versions = ">=3.8"
 groups = ["dev"]
 files = [
-    {file = "mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d"},
-    {file = "mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782"},
+    {file = "mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505"},
+    {file = "mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558"},
 ]
 
 [[package]]
@@ -823,14 +823,14 @@ files = [
 
 [[package]]
 name = "packaging"
-version = "24.2"
+version = "25.0"
 description = "Core utilities for Python packages"
 optional = false
 python-versions = ">=3.8"
 groups = ["main", "dev"]
 files = [
-    {file = "packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759"},
-    {file = "packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f"},
+    {file = "packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484"},
+    {file = "packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f"},
 ]
 
 [[package]]
@@ -906,20 +906,20 @@ ptyprocess = ">=0.5"
 
 [[package]]
 name = "platformdirs"
-version = "4.3.6"
+version = "4.3.7"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["dev"]
 files = [
-    {file = "platformdirs-4.3.6-py3-none-any.whl", hash = "sha256:73e575e1408ab8103900836b97580d5307456908a03e92031bab39e4554cc3fb"},
-    {file = "platformdirs-4.3.6.tar.gz", hash = "sha256:357fb2acbc885b0419afd3ce3ed34564c13c9b95c89360cd9563f73aa5e2b907"},
+    {file = "platformdirs-4.3.7-py3-none-any.whl", hash = "sha256:a03875334331946f13c549dbd8f4bac7a13a50a895a0eb1e8c6a8ace80d40a94"},
+    {file = "platformdirs-4.3.7.tar.gz", hash = "sha256:eb437d586b6a0986388f0d6f74aa0cde27b48d0e3d66843640bfb6bdcdb6e351"},
 ]
 
 [package.extras]
-docs = ["furo (>=2024.8.6)", "proselint (>=0.14)", "sphinx (>=8.0.2)", "sphinx-autodoc-typehints (>=2.4)"]
-test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=8.3.2)", "pytest-cov (>=5)", "pytest-mock (>=3.14)"]
-type = ["mypy (>=1.11.2)"]
+docs = ["furo (>=2024.8.6)", "proselint (>=0.14)", "sphinx (>=8.1.3)", "sphinx-autodoc-typehints (>=3)"]
+test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=8.3.4)", "pytest-cov (>=6)", "pytest-mock (>=3.14)"]
+type = ["mypy (>=1.14.1)"]
 
 [[package]]
 name = "pluggy"
@@ -958,14 +958,14 @@ poetry-plugin = ["poetry (>=1.2.0,<3.0.0) ; python_version < \"4.0\""]
 
 [[package]]
 name = "prompt-toolkit"
-version = "3.0.50"
+version = "3.0.51"
 description = "Library for building powerful interactive command lines in Python"
 optional = false
-python-versions = ">=3.8.0"
+python-versions = ">=3.8"
 groups = ["dev"]
 files = [
-    {file = "prompt_toolkit-3.0.50-py3-none-any.whl", hash = "sha256:9b6427eb19e479d98acff65196a307c555eb567989e6d88ebbb1b509d9779198"},
-    {file = "prompt_toolkit-3.0.50.tar.gz", hash = "sha256:544748f3860a2623ca5cd6d2795e7a14f3d0e1c3c9728359013f79877fc89bab"},
+    {file = "prompt_toolkit-3.0.51-py3-none-any.whl", hash = "sha256:52742911fde84e2d423e2f9a4cf1de7d7ac4e51958f648d9540e0fb8db077b07"},
+    {file = "prompt_toolkit-3.0.51.tar.gz", hash = "sha256:931a162e3b27fc90c86f1b48bb1fb2c528c2761475e57c9c06de13311c7b54ed"},
 ]
 
 [package.dependencies]
@@ -1001,14 +1001,14 @@ tests = ["pytest"]
 
 [[package]]
 name = "pycodestyle"
-version = "2.12.1"
+version = "2.13.0"
 description = "Python style guide checker"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["dev"]
 files = [
-    {file = "pycodestyle-2.12.1-py2.py3-none-any.whl", hash = "sha256:46f0fb92069a7c28ab7bb558f05bfc0110dac69a0cd23c61ea0040283a9d78b3"},
-    {file = "pycodestyle-2.12.1.tar.gz", hash = "sha256:6838eae08bbce4f6accd5d5572075c63626a15ee3e6f842df996bf62f6d73521"},
+    {file = "pycodestyle-2.13.0-py2.py3-none-any.whl", hash = "sha256:35863c5974a271c7a726ed228a14a4f6daf49df369d8c50cd9a6f58a5e143ba9"},
+    {file = "pycodestyle-2.13.0.tar.gz", hash = "sha256:c8415bf09abe81d9c7f872502a6eee881fbe85d8763dd5b9924bb0a01d67efae"},
 ]
 
 [[package]]
@@ -1026,20 +1026,21 @@ files = [
 
 [[package]]
 name = "pydantic"
-version = "2.10.6"
+version = "2.11.3"
 description = "Data validation using Python type hints"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "pydantic-2.10.6-py3-none-any.whl", hash = "sha256:427d664bf0b8a2b34ff5dd0f5a18df00591adcee7198fbd71981054cef37b584"},
-    {file = "pydantic-2.10.6.tar.gz", hash = "sha256:ca5daa827cce33de7a42be142548b0096bf05a7e7b365aebfa5f8eeec7128236"},
+    {file = "pydantic-2.11.3-py3-none-any.whl", hash = "sha256:a082753436a07f9ba1289c6ffa01cd93db3548776088aa917cc43b63f68fa60f"},
+    {file = "pydantic-2.11.3.tar.gz", hash = "sha256:7471657138c16adad9322fe3070c0116dd6c3ad8d649300e3cbdfe91f4db4ec3"},
 ]
 
 [package.dependencies]
 annotated-types = ">=0.6.0"
-pydantic-core = "2.27.2"
+pydantic-core = "2.33.1"
 typing-extensions = ">=4.12.2"
+typing-inspection = ">=0.4.0"
 
 [package.extras]
 email = ["email-validator (>=2.0.0)"]
@@ -1047,112 +1048,111 @@ timezone = ["tzdata ; python_version >= \"3.9\" and platform_system == \"Windows
 
 [[package]]
 name = "pydantic-core"
-version = "2.27.2"
+version = "2.33.1"
 description = "Core functionality for Pydantic validation and serialization"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "pydantic_core-2.27.2-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:2d367ca20b2f14095a8f4fa1210f5a7b78b8a20009ecced6b12818f455b1e9fa"},
-    {file = "pydantic_core-2.27.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:491a2b73db93fab69731eaee494f320faa4e093dbed776be1a829c2eb222c34c"},
-    {file = "pydantic_core-2.27.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7969e133a6f183be60e9f6f56bfae753585680f3b7307a8e555a948d443cc05a"},
-    {file = "pydantic_core-2.27.2-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3de9961f2a346257caf0aa508a4da705467f53778e9ef6fe744c038119737ef5"},
-    {file = "pydantic_core-2.27.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e2bb4d3e5873c37bb3dd58714d4cd0b0e6238cebc4177ac8fe878f8b3aa8e74c"},
-    {file = "pydantic_core-2.27.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:280d219beebb0752699480fe8f1dc61ab6615c2046d76b7ab7ee38858de0a4e7"},
-    {file = "pydantic_core-2.27.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47956ae78b6422cbd46f772f1746799cbb862de838fd8d1fbd34a82e05b0983a"},
-    {file = "pydantic_core-2.27.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:14d4a5c49d2f009d62a2a7140d3064f686d17a5d1a268bc641954ba181880236"},
-    {file = "pydantic_core-2.27.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:337b443af21d488716f8d0b6164de833e788aa6bd7e3a39c005febc1284f4962"},
-    {file = "pydantic_core-2.27.2-cp310-cp310-musllinux_1_1_armv7l.whl", hash = "sha256:03d0f86ea3184a12f41a2d23f7ccb79cdb5a18e06993f8a45baa8dfec746f0e9"},
-    {file = "pydantic_core-2.27.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:7041c36f5680c6e0f08d922aed302e98b3745d97fe1589db0a3eebf6624523af"},
-    {file = "pydantic_core-2.27.2-cp310-cp310-win32.whl", hash = "sha256:50a68f3e3819077be2c98110c1f9dcb3817e93f267ba80a2c05bb4f8799e2ff4"},
-    {file = "pydantic_core-2.27.2-cp310-cp310-win_amd64.whl", hash = "sha256:e0fd26b16394ead34a424eecf8a31a1f5137094cabe84a1bcb10fa6ba39d3d31"},
-    {file = "pydantic_core-2.27.2-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:8e10c99ef58cfdf2a66fc15d66b16c4a04f62bca39db589ae8cba08bc55331bc"},
-    {file = "pydantic_core-2.27.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:26f32e0adf166a84d0cb63be85c562ca8a6fa8de28e5f0d92250c6b7e9e2aff7"},
-    {file = "pydantic_core-2.27.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8c19d1ea0673cd13cc2f872f6c9ab42acc4e4f492a7ca9d3795ce2b112dd7e15"},
-    {file = "pydantic_core-2.27.2-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5e68c4446fe0810e959cdff46ab0a41ce2f2c86d227d96dc3847af0ba7def306"},
-    {file = "pydantic_core-2.27.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d9640b0059ff4f14d1f37321b94061c6db164fbe49b334b31643e0528d100d99"},
-    {file = "pydantic_core-2.27.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:40d02e7d45c9f8af700f3452f329ead92da4c5f4317ca9b896de7ce7199ea459"},
-    {file = "pydantic_core-2.27.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1c1fd185014191700554795c99b347d64f2bb637966c4cfc16998a0ca700d048"},
-    {file = "pydantic_core-2.27.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d81d2068e1c1228a565af076598f9e7451712700b673de8f502f0334f281387d"},
-    {file = "pydantic_core-2.27.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:1a4207639fb02ec2dbb76227d7c751a20b1a6b4bc52850568e52260cae64ca3b"},
-    {file = "pydantic_core-2.27.2-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:3de3ce3c9ddc8bbd88f6e0e304dea0e66d843ec9de1b0042b0911c1663ffd474"},
-    {file = "pydantic_core-2.27.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:30c5f68ded0c36466acede341551106821043e9afaad516adfb6e8fa80a4e6a6"},
-    {file = "pydantic_core-2.27.2-cp311-cp311-win32.whl", hash = "sha256:c70c26d2c99f78b125a3459f8afe1aed4d9687c24fd677c6a4436bc042e50d6c"},
-    {file = "pydantic_core-2.27.2-cp311-cp311-win_amd64.whl", hash = "sha256:08e125dbdc505fa69ca7d9c499639ab6407cfa909214d500897d02afb816e7cc"},
-    {file = "pydantic_core-2.27.2-cp311-cp311-win_arm64.whl", hash = "sha256:26f0d68d4b235a2bae0c3fc585c585b4ecc51382db0e3ba402a22cbc440915e4"},
-    {file = "pydantic_core-2.27.2-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:9e0c8cfefa0ef83b4da9588448b6d8d2a2bf1a53c3f1ae5fca39eb3061e2f0b0"},
-    {file = "pydantic_core-2.27.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:83097677b8e3bd7eaa6775720ec8e0405f1575015a463285a92bfdfe254529ef"},
-    {file = "pydantic_core-2.27.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:172fce187655fece0c90d90a678424b013f8fbb0ca8b036ac266749c09438cb7"},
-    {file = "pydantic_core-2.27.2-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:519f29f5213271eeeeb3093f662ba2fd512b91c5f188f3bb7b27bc5973816934"},
-    {file = "pydantic_core-2.27.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:05e3a55d124407fffba0dd6b0c0cd056d10e983ceb4e5dbd10dda135c31071d6"},
-    {file = "pydantic_core-2.27.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9c3ed807c7b91de05e63930188f19e921d1fe90de6b4f5cd43ee7fcc3525cb8c"},
-    {file = "pydantic_core-2.27.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6fb4aadc0b9a0c063206846d603b92030eb6f03069151a625667f982887153e2"},
-    {file = "pydantic_core-2.27.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:28ccb213807e037460326424ceb8b5245acb88f32f3d2777427476e1b32c48c4"},
-    {file = "pydantic_core-2.27.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:de3cd1899e2c279b140adde9357c4495ed9d47131b4a4eaff9052f23398076b3"},
-    {file = "pydantic_core-2.27.2-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:220f892729375e2d736b97d0e51466252ad84c51857d4d15f5e9692f9ef12be4"},
-    {file = "pydantic_core-2.27.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:a0fcd29cd6b4e74fe8ddd2c90330fd8edf2e30cb52acda47f06dd615ae72da57"},
-    {file = "pydantic_core-2.27.2-cp312-cp312-win32.whl", hash = "sha256:1e2cb691ed9834cd6a8be61228471d0a503731abfb42f82458ff27be7b2186fc"},
-    {file = "pydantic_core-2.27.2-cp312-cp312-win_amd64.whl", hash = "sha256:cc3f1a99a4f4f9dd1de4fe0312c114e740b5ddead65bb4102884b384c15d8bc9"},
-    {file = "pydantic_core-2.27.2-cp312-cp312-win_arm64.whl", hash = "sha256:3911ac9284cd8a1792d3cb26a2da18f3ca26c6908cc434a18f730dc0db7bfa3b"},
-    {file = "pydantic_core-2.27.2-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:7d14bd329640e63852364c306f4d23eb744e0f8193148d4044dd3dacdaacbd8b"},
-    {file = "pydantic_core-2.27.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:82f91663004eb8ed30ff478d77c4d1179b3563df6cdb15c0817cd1cdaf34d154"},
-    {file = "pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:71b24c7d61131bb83df10cc7e687433609963a944ccf45190cfc21e0887b08c9"},
-    {file = "pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fa8e459d4954f608fa26116118bb67f56b93b209c39b008277ace29937453dc9"},
-    {file = "pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ce8918cbebc8da707ba805b7fd0b382816858728ae7fe19a942080c24e5b7cd1"},
-    {file = "pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:eda3f5c2a021bbc5d976107bb302e0131351c2ba54343f8a496dc8783d3d3a6a"},
-    {file = "pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bd8086fa684c4775c27f03f062cbb9eaa6e17f064307e86b21b9e0abc9c0f02e"},
-    {file = "pydantic_core-2.27.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8d9b3388db186ba0c099a6d20f0604a44eabdeef1777ddd94786cdae158729e4"},
-    {file = "pydantic_core-2.27.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:7a66efda2387de898c8f38c0cf7f14fca0b51a8ef0b24bfea5849f1b3c95af27"},
-    {file = "pydantic_core-2.27.2-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:18a101c168e4e092ab40dbc2503bdc0f62010e95d292b27827871dc85450d7ee"},
-    {file = "pydantic_core-2.27.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:ba5dd002f88b78a4215ed2f8ddbdf85e8513382820ba15ad5ad8955ce0ca19a1"},
-    {file = "pydantic_core-2.27.2-cp313-cp313-win32.whl", hash = "sha256:1ebaf1d0481914d004a573394f4be3a7616334be70261007e47c2a6fe7e50130"},
-    {file = "pydantic_core-2.27.2-cp313-cp313-win_amd64.whl", hash = "sha256:953101387ecf2f5652883208769a79e48db18c6df442568a0b5ccd8c2723abee"},
-    {file = "pydantic_core-2.27.2-cp313-cp313-win_arm64.whl", hash = "sha256:ac4dbfd1691affb8f48c2c13241a2e3b60ff23247cbcf981759c768b6633cf8b"},
-    {file = "pydantic_core-2.27.2-cp38-cp38-macosx_10_12_x86_64.whl", hash = "sha256:d3e8d504bdd3f10835468f29008d72fc8359d95c9c415ce6e767203db6127506"},
-    {file = "pydantic_core-2.27.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:521eb9b7f036c9b6187f0b47318ab0d7ca14bd87f776240b90b21c1f4f149320"},
-    {file = "pydantic_core-2.27.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:85210c4d99a0114f5a9481b44560d7d1e35e32cc5634c656bc48e590b669b145"},
-    {file = "pydantic_core-2.27.2-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d716e2e30c6f140d7560ef1538953a5cd1a87264c737643d481f2779fc247fe1"},
-    {file = "pydantic_core-2.27.2-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f66d89ba397d92f840f8654756196d93804278457b5fbede59598a1f9f90b228"},
-    {file = "pydantic_core-2.27.2-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:669e193c1c576a58f132e3158f9dfa9662969edb1a250c54d8fa52590045f046"},
-    {file = "pydantic_core-2.27.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9fdbe7629b996647b99c01b37f11170a57ae675375b14b8c13b8518b8320ced5"},
-    {file = "pydantic_core-2.27.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d262606bf386a5ba0b0af3b97f37c83d7011439e3dc1a9298f21efb292e42f1a"},
-    {file = "pydantic_core-2.27.2-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:cabb9bcb7e0d97f74df8646f34fc76fbf793b7f6dc2438517d7a9e50eee4f14d"},
-    {file = "pydantic_core-2.27.2-cp38-cp38-musllinux_1_1_armv7l.whl", hash = "sha256:d2d63f1215638d28221f664596b1ccb3944f6e25dd18cd3b86b0a4c408d5ebb9"},
-    {file = "pydantic_core-2.27.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:bca101c00bff0adb45a833f8451b9105d9df18accb8743b08107d7ada14bd7da"},
-    {file = "pydantic_core-2.27.2-cp38-cp38-win32.whl", hash = "sha256:f6f8e111843bbb0dee4cb6594cdc73e79b3329b526037ec242a3e49012495b3b"},
-    {file = "pydantic_core-2.27.2-cp38-cp38-win_amd64.whl", hash = "sha256:fd1aea04935a508f62e0d0ef1f5ae968774a32afc306fb8545e06f5ff5cdf3ad"},
-    {file = "pydantic_core-2.27.2-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:c10eb4f1659290b523af58fa7cffb452a61ad6ae5613404519aee4bfbf1df993"},
-    {file = "pydantic_core-2.27.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:ef592d4bad47296fb11f96cd7dc898b92e795032b4894dfb4076cfccd43a9308"},
-    {file = "pydantic_core-2.27.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c61709a844acc6bf0b7dce7daae75195a10aac96a596ea1b776996414791ede4"},
-    {file = "pydantic_core-2.27.2-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:42c5f762659e47fdb7b16956c71598292f60a03aa92f8b6351504359dbdba6cf"},
-    {file = "pydantic_core-2.27.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4c9775e339e42e79ec99c441d9730fccf07414af63eac2f0e48e08fd38a64d76"},
-    {file = "pydantic_core-2.27.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:57762139821c31847cfb2df63c12f725788bd9f04bc2fb392790959b8f70f118"},
-    {file = "pydantic_core-2.27.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0d1e85068e818c73e048fe28cfc769040bb1f475524f4745a5dc621f75ac7630"},
-    {file = "pydantic_core-2.27.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:097830ed52fd9e427942ff3b9bc17fab52913b2f50f2880dc4a5611446606a54"},
-    {file = "pydantic_core-2.27.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:044a50963a614ecfae59bb1eaf7ea7efc4bc62f49ed594e18fa1e5d953c40e9f"},
-    {file = "pydantic_core-2.27.2-cp39-cp39-musllinux_1_1_armv7l.whl", hash = "sha256:4e0b4220ba5b40d727c7f879eac379b822eee5d8fff418e9d3381ee45b3b0362"},
-    {file = "pydantic_core-2.27.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:5e4f4bb20d75e9325cc9696c6802657b58bc1dbbe3022f32cc2b2b632c3fbb96"},
-    {file = "pydantic_core-2.27.2-cp39-cp39-win32.whl", hash = "sha256:cca63613e90d001b9f2f9a9ceb276c308bfa2a43fafb75c8031c4f66039e8c6e"},
-    {file = "pydantic_core-2.27.2-cp39-cp39-win_amd64.whl", hash = "sha256:77d1bca19b0f7021b3a982e6f903dcd5b2b06076def36a652e3907f596e29f67"},
-    {file = "pydantic_core-2.27.2-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:2bf14caea37e91198329b828eae1618c068dfb8ef17bb33287a7ad4b61ac314e"},
-    {file = "pydantic_core-2.27.2-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:b0cb791f5b45307caae8810c2023a184c74605ec3bcbb67d13846c28ff731ff8"},
-    {file = "pydantic_core-2.27.2-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:688d3fd9fcb71f41c4c015c023d12a79d1c4c0732ec9eb35d96e3388a120dcf3"},
-    {file = "pydantic_core-2.27.2-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3d591580c34f4d731592f0e9fe40f9cc1b430d297eecc70b962e93c5c668f15f"},
-    {file = "pydantic_core-2.27.2-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:82f986faf4e644ffc189a7f1aafc86e46ef70372bb153e7001e8afccc6e54133"},
-    {file = "pydantic_core-2.27.2-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:bec317a27290e2537f922639cafd54990551725fc844249e64c523301d0822fc"},
-    {file = "pydantic_core-2.27.2-pp310-pypy310_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:0296abcb83a797db256b773f45773da397da75a08f5fcaef41f2044adec05f50"},
-    {file = "pydantic_core-2.27.2-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:0d75070718e369e452075a6017fbf187f788e17ed67a3abd47fa934d001863d9"},
-    {file = "pydantic_core-2.27.2-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:7e17b560be3c98a8e3aa66ce828bdebb9e9ac6ad5466fba92eb74c4c95cb1151"},
-    {file = "pydantic_core-2.27.2-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:c33939a82924da9ed65dab5a65d427205a73181d8098e79b6b426bdf8ad4e656"},
-    {file = "pydantic_core-2.27.2-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:00bad2484fa6bda1e216e7345a798bd37c68fb2d97558edd584942aa41b7d278"},
-    {file = "pydantic_core-2.27.2-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c817e2b40aba42bac6f457498dacabc568c3b7a986fc9ba7c8d9d260b71485fb"},
-    {file = "pydantic_core-2.27.2-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:251136cdad0cb722e93732cb45ca5299fb56e1344a833640bf93b2803f8d1bfd"},
-    {file = "pydantic_core-2.27.2-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d2088237af596f0a524d3afc39ab3b036e8adb054ee57cbb1dcf8e09da5b29cc"},
-    {file = "pydantic_core-2.27.2-pp39-pypy39_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:d4041c0b966a84b4ae7a09832eb691a35aec90910cd2dbe7a208de59be77965b"},
-    {file = "pydantic_core-2.27.2-pp39-pypy39_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:8083d4e875ebe0b864ffef72a4304827015cff328a1be6e22cc850753bfb122b"},
-    {file = "pydantic_core-2.27.2-pp39-pypy39_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:f141ee28a0ad2123b6611b6ceff018039df17f32ada8b534e6aa039545a3efb2"},
-    {file = "pydantic_core-2.27.2-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:7d0c8399fcc1848491f00e0314bd59fb34a9c008761bcb422a057670c3f65e35"},
-    {file = "pydantic_core-2.27.2.tar.gz", hash = "sha256:eb026e5a4c1fee05726072337ff51d1efb6f59090b7da90d30ea58625b1ffb39"},
+    {file = "pydantic_core-2.33.1-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:3077cfdb6125cc8dab61b155fdd714663e401f0e6883f9632118ec12cf42df26"},
+    {file = "pydantic_core-2.33.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8ffab8b2908d152e74862d276cf5017c81a2f3719f14e8e3e8d6b83fda863927"},
+    {file = "pydantic_core-2.33.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5183e4f6a2d468787243ebcd70cf4098c247e60d73fb7d68d5bc1e1beaa0c4db"},
+    {file = "pydantic_core-2.33.1-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:398a38d323f37714023be1e0285765f0a27243a8b1506b7b7de87b647b517e48"},
+    {file = "pydantic_core-2.33.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:87d3776f0001b43acebfa86f8c64019c043b55cc5a6a2e313d728b5c95b46969"},
+    {file = "pydantic_core-2.33.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c566dd9c5f63d22226409553531f89de0cac55397f2ab8d97d6f06cfce6d947e"},
+    {file = "pydantic_core-2.33.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a0d5f3acc81452c56895e90643a625302bd6be351e7010664151cc55b7b97f89"},
+    {file = "pydantic_core-2.33.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d3a07fadec2a13274a8d861d3d37c61e97a816beae717efccaa4b36dfcaadcde"},
+    {file = "pydantic_core-2.33.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:f99aeda58dce827f76963ee87a0ebe75e648c72ff9ba1174a253f6744f518f65"},
+    {file = "pydantic_core-2.33.1-cp310-cp310-musllinux_1_1_armv7l.whl", hash = "sha256:902dbc832141aa0ec374f4310f1e4e7febeebc3256f00dc359a9ac3f264a45dc"},
+    {file = "pydantic_core-2.33.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:fe44d56aa0b00d66640aa84a3cbe80b7a3ccdc6f0b1ca71090696a6d4777c091"},
+    {file = "pydantic_core-2.33.1-cp310-cp310-win32.whl", hash = "sha256:ed3eb16d51257c763539bde21e011092f127a2202692afaeaccb50db55a31383"},
+    {file = "pydantic_core-2.33.1-cp310-cp310-win_amd64.whl", hash = "sha256:694ad99a7f6718c1a498dc170ca430687a39894a60327f548e02a9c7ee4b6504"},
+    {file = "pydantic_core-2.33.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:6e966fc3caaf9f1d96b349b0341c70c8d6573bf1bac7261f7b0ba88f96c56c24"},
+    {file = "pydantic_core-2.33.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:bfd0adeee563d59c598ceabddf2c92eec77abcb3f4a391b19aa7366170bd9e30"},
+    {file = "pydantic_core-2.33.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:91815221101ad3c6b507804178a7bb5cb7b2ead9ecd600041669c8d805ebd595"},
+    {file = "pydantic_core-2.33.1-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9fea9c1869bb4742d174a57b4700c6dadea951df8b06de40c2fedb4f02931c2e"},
+    {file = "pydantic_core-2.33.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1d20eb4861329bb2484c021b9d9a977566ab16d84000a57e28061151c62b349a"},
+    {file = "pydantic_core-2.33.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0fb935c5591573ae3201640579f30128ccc10739b45663f93c06796854405505"},
+    {file = "pydantic_core-2.33.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c964fd24e6166420d18fb53996d8c9fd6eac9bf5ae3ec3d03015be4414ce497f"},
+    {file = "pydantic_core-2.33.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:681d65e9011f7392db5aa002b7423cc442d6a673c635668c227c6c8d0e5a4f77"},
+    {file = "pydantic_core-2.33.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:e100c52f7355a48413e2999bfb4e139d2977a904495441b374f3d4fb4a170961"},
+    {file = "pydantic_core-2.33.1-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:048831bd363490be79acdd3232f74a0e9951b11b2b4cc058aeb72b22fdc3abe1"},
+    {file = "pydantic_core-2.33.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:bdc84017d28459c00db6f918a7272a5190bec3090058334e43a76afb279eac7c"},
+    {file = "pydantic_core-2.33.1-cp311-cp311-win32.whl", hash = "sha256:32cd11c5914d1179df70406427097c7dcde19fddf1418c787540f4b730289896"},
+    {file = "pydantic_core-2.33.1-cp311-cp311-win_amd64.whl", hash = "sha256:2ea62419ba8c397e7da28a9170a16219d310d2cf4970dbc65c32faf20d828c83"},
+    {file = "pydantic_core-2.33.1-cp311-cp311-win_arm64.whl", hash = "sha256:fc903512177361e868bc1f5b80ac8c8a6e05fcdd574a5fb5ffeac5a9982b9e89"},
+    {file = "pydantic_core-2.33.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:1293d7febb995e9d3ec3ea09caf1a26214eec45b0f29f6074abb004723fc1de8"},
+    {file = "pydantic_core-2.33.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:99b56acd433386c8f20be5c4000786d1e7ca0523c8eefc995d14d79c7a081498"},
+    {file = "pydantic_core-2.33.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:35a5ec3fa8c2fe6c53e1b2ccc2454398f95d5393ab398478f53e1afbbeb4d939"},
+    {file = "pydantic_core-2.33.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b172f7b9d2f3abc0efd12e3386f7e48b576ef309544ac3a63e5e9cdd2e24585d"},
+    {file = "pydantic_core-2.33.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9097b9f17f91eea659b9ec58148c0747ec354a42f7389b9d50701610d86f812e"},
+    {file = "pydantic_core-2.33.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cc77ec5b7e2118b152b0d886c7514a4653bcb58c6b1d760134a9fab915f777b3"},
+    {file = "pydantic_core-2.33.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d5e3d15245b08fa4a84cefc6c9222e6f37c98111c8679fbd94aa145f9a0ae23d"},
+    {file = "pydantic_core-2.33.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ef99779001d7ac2e2461d8ab55d3373fe7315caefdbecd8ced75304ae5a6fc6b"},
+    {file = "pydantic_core-2.33.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:fc6bf8869e193855e8d91d91f6bf59699a5cdfaa47a404e278e776dd7f168b39"},
+    {file = "pydantic_core-2.33.1-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:b1caa0bc2741b043db7823843e1bde8aaa58a55a58fda06083b0569f8b45693a"},
+    {file = "pydantic_core-2.33.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:ec259f62538e8bf364903a7d0d0239447059f9434b284f5536e8402b7dd198db"},
+    {file = "pydantic_core-2.33.1-cp312-cp312-win32.whl", hash = "sha256:e14f369c98a7c15772b9da98987f58e2b509a93235582838bd0d1d8c08b68fda"},
+    {file = "pydantic_core-2.33.1-cp312-cp312-win_amd64.whl", hash = "sha256:1c607801d85e2e123357b3893f82c97a42856192997b95b4d8325deb1cd0c5f4"},
+    {file = "pydantic_core-2.33.1-cp312-cp312-win_arm64.whl", hash = "sha256:8d13f0276806ee722e70a1c93da19748594f19ac4299c7e41237fc791d1861ea"},
+    {file = "pydantic_core-2.33.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:70af6a21237b53d1fe7b9325b20e65cbf2f0a848cf77bed492b029139701e66a"},
+    {file = "pydantic_core-2.33.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:282b3fe1bbbe5ae35224a0dbd05aed9ccabccd241e8e6b60370484234b456266"},
+    {file = "pydantic_core-2.33.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4b315e596282bbb5822d0c7ee9d255595bd7506d1cb20c2911a4da0b970187d3"},
+    {file = "pydantic_core-2.33.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1dfae24cf9921875ca0ca6a8ecb4bb2f13c855794ed0d468d6abbec6e6dcd44a"},
+    {file = "pydantic_core-2.33.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6dd8ecfde08d8bfadaea669e83c63939af76f4cf5538a72597016edfa3fad516"},
+    {file = "pydantic_core-2.33.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2f593494876eae852dc98c43c6f260f45abdbfeec9e4324e31a481d948214764"},
+    {file = "pydantic_core-2.33.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:948b73114f47fd7016088e5186d13faf5e1b2fe83f5e320e371f035557fd264d"},
+    {file = "pydantic_core-2.33.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e11f3864eb516af21b01e25fac915a82e9ddad3bb0fb9e95a246067398b435a4"},
+    {file = "pydantic_core-2.33.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:549150be302428b56fdad0c23c2741dcdb5572413776826c965619a25d9c6bde"},
+    {file = "pydantic_core-2.33.1-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:495bc156026efafd9ef2d82372bd38afce78ddd82bf28ef5276c469e57c0c83e"},
+    {file = "pydantic_core-2.33.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:ec79de2a8680b1a67a07490bddf9636d5c2fab609ba8c57597e855fa5fa4dacd"},
+    {file = "pydantic_core-2.33.1-cp313-cp313-win32.whl", hash = "sha256:ee12a7be1742f81b8a65b36c6921022301d466b82d80315d215c4c691724986f"},
+    {file = "pydantic_core-2.33.1-cp313-cp313-win_amd64.whl", hash = "sha256:ede9b407e39949d2afc46385ce6bd6e11588660c26f80576c11c958e6647bc40"},
+    {file = "pydantic_core-2.33.1-cp313-cp313-win_arm64.whl", hash = "sha256:aa687a23d4b7871a00e03ca96a09cad0f28f443690d300500603bd0adba4b523"},
+    {file = "pydantic_core-2.33.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:401d7b76e1000d0dd5538e6381d28febdcacb097c8d340dde7d7fc6e13e9f95d"},
+    {file = "pydantic_core-2.33.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7aeb055a42d734c0255c9e489ac67e75397d59c6fbe60d155851e9782f276a9c"},
+    {file = "pydantic_core-2.33.1-cp313-cp313t-win_amd64.whl", hash = "sha256:338ea9b73e6e109f15ab439e62cb3b78aa752c7fd9536794112e14bee02c8d18"},
+    {file = "pydantic_core-2.33.1-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:5ab77f45d33d264de66e1884fca158bc920cb5e27fd0764a72f72f5756ae8bdb"},
+    {file = "pydantic_core-2.33.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e7aaba1b4b03aaea7bb59e1b5856d734be011d3e6d98f5bcaa98cb30f375f2ad"},
+    {file = "pydantic_core-2.33.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7fb66263e9ba8fea2aa85e1e5578980d127fb37d7f2e292773e7bc3a38fb0c7b"},
+    {file = "pydantic_core-2.33.1-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3f2648b9262607a7fb41d782cc263b48032ff7a03a835581abbf7a3bec62bcf5"},
+    {file = "pydantic_core-2.33.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:723c5630c4259400818b4ad096735a829074601805d07f8cafc366d95786d331"},
+    {file = "pydantic_core-2.33.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d100e3ae783d2167782391e0c1c7a20a31f55f8015f3293647544df3f9c67824"},
+    {file = "pydantic_core-2.33.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:177d50460bc976a0369920b6c744d927b0ecb8606fb56858ff542560251b19e5"},
+    {file = "pydantic_core-2.33.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a3edde68d1a1f9af1273b2fe798997b33f90308fb6d44d8550c89fc6a3647cf6"},
+    {file = "pydantic_core-2.33.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:a62c3c3ef6a7e2c45f7853b10b5bc4ddefd6ee3cd31024754a1a5842da7d598d"},
+    {file = "pydantic_core-2.33.1-cp39-cp39-musllinux_1_1_armv7l.whl", hash = "sha256:c91dbb0ab683fa0cd64a6e81907c8ff41d6497c346890e26b23de7ee55353f96"},
+    {file = "pydantic_core-2.33.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:9f466e8bf0a62dc43e068c12166281c2eca72121dd2adc1040f3aa1e21ef8599"},
+    {file = "pydantic_core-2.33.1-cp39-cp39-win32.whl", hash = "sha256:ab0277cedb698749caada82e5d099dc9fed3f906a30d4c382d1a21725777a1e5"},
+    {file = "pydantic_core-2.33.1-cp39-cp39-win_amd64.whl", hash = "sha256:5773da0ee2d17136b1f1c6fbde543398d452a6ad2a7b54ea1033e2daa739b8d2"},
+    {file = "pydantic_core-2.33.1-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:5c834f54f8f4640fd7e4b193f80eb25a0602bba9e19b3cd2fc7ffe8199f5ae02"},
+    {file = "pydantic_core-2.33.1-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:049e0de24cf23766f12cc5cc71d8abc07d4a9deb9061b334b62093dedc7cb068"},
+    {file = "pydantic_core-2.33.1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1a28239037b3d6f16916a4c831a5a0eadf856bdd6d2e92c10a0da3a59eadcf3e"},
+    {file = "pydantic_core-2.33.1-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9d3da303ab5f378a268fa7d45f37d7d85c3ec19769f28d2cc0c61826a8de21fe"},
+    {file = "pydantic_core-2.33.1-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:25626fb37b3c543818c14821afe0fd3830bc327a43953bc88db924b68c5723f1"},
+    {file = "pydantic_core-2.33.1-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:3ab2d36e20fbfcce8f02d73c33a8a7362980cff717926bbae030b93ae46b56c7"},
+    {file = "pydantic_core-2.33.1-pp310-pypy310_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:2f9284e11c751b003fd4215ad92d325d92c9cb19ee6729ebd87e3250072cdcde"},
+    {file = "pydantic_core-2.33.1-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:048c01eee07d37cbd066fc512b9d8b5ea88ceeb4e629ab94b3e56965ad655add"},
+    {file = "pydantic_core-2.33.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:5ccd429694cf26af7997595d627dd2637e7932214486f55b8a357edaac9dae8c"},
+    {file = "pydantic_core-2.33.1-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:3a371dc00282c4b84246509a5ddc808e61b9864aa1eae9ecc92bb1268b82db4a"},
+    {file = "pydantic_core-2.33.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:f59295ecc75a1788af8ba92f2e8c6eeaa5a94c22fc4d151e8d9638814f85c8fc"},
+    {file = "pydantic_core-2.33.1-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:08530b8ac922003033f399128505f513e30ca770527cc8bbacf75a84fcc2c74b"},
+    {file = "pydantic_core-2.33.1-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bae370459da6a5466978c0eacf90690cb57ec9d533f8e63e564ef3822bfa04fe"},
+    {file = "pydantic_core-2.33.1-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e3de2777e3b9f4d603112f78006f4ae0acb936e95f06da6cb1a45fbad6bdb4b5"},
+    {file = "pydantic_core-2.33.1-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:3a64e81e8cba118e108d7126362ea30e021291b7805d47e4896e52c791be2761"},
+    {file = "pydantic_core-2.33.1-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:52928d8c1b6bda03cc6d811e8923dffc87a2d3c8b3bfd2ce16471c7147a24850"},
+    {file = "pydantic_core-2.33.1-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:1b30d92c9412beb5ac6b10a3eb7ef92ccb14e3f2a8d7732e2d739f58b3aa7544"},
+    {file = "pydantic_core-2.33.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:f995719707e0e29f0f41a8aa3bcea6e761a36c9136104d3189eafb83f5cec5e5"},
+    {file = "pydantic_core-2.33.1-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:7edbc454a29fc6aeae1e1eecba4f07b63b8d76e76a748532233c4c167b4cb9ea"},
+    {file = "pydantic_core-2.33.1-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:ad05b683963f69a1d5d2c2bdab1274a31221ca737dbbceaa32bcb67359453cdd"},
+    {file = "pydantic_core-2.33.1-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:df6a94bf9452c6da9b5d76ed229a5683d0306ccb91cca8e1eea883189780d568"},
+    {file = "pydantic_core-2.33.1-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7965c13b3967909a09ecc91f21d09cfc4576bf78140b988904e94f130f188396"},
+    {file = "pydantic_core-2.33.1-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:3f1fdb790440a34f6ecf7679e1863b825cb5ffde858a9197f851168ed08371e5"},
+    {file = "pydantic_core-2.33.1-pp39-pypy39_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:5277aec8d879f8d05168fdd17ae811dd313b8ff894aeeaf7cd34ad28b4d77e33"},
+    {file = "pydantic_core-2.33.1-pp39-pypy39_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:8ab581d3530611897d863d1a649fb0644b860286b4718db919bfd51ece41f10b"},
+    {file = "pydantic_core-2.33.1-pp39-pypy39_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:0483847fa9ad5e3412265c1bd72aad35235512d9ce9d27d81a56d935ef489672"},
+    {file = "pydantic_core-2.33.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:de9e06abe3cc5ec6a2d5f75bc99b0bdca4f5c719a5b34026f8c57efbdecd2ee3"},
+    {file = "pydantic_core-2.33.1.tar.gz", hash = "sha256:bcc9c6fdb0ced789245b02b7d6603e17d1563064ddcfc36f046b61c0c05dd9df"},
 ]
 
 [package.dependencies]
@@ -1160,14 +1160,14 @@ typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
 
 [[package]]
 name = "pyflakes"
-version = "3.2.0"
+version = "3.3.2"
 description = "passive checker of Python programs"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["dev"]
 files = [
-    {file = "pyflakes-3.2.0-py2.py3-none-any.whl", hash = "sha256:84b5be138a2dfbb40689ca07e2152deb896a65c3a3e24c251c5c62489568074a"},
-    {file = "pyflakes-3.2.0.tar.gz", hash = "sha256:1c61603ff154621fb2a9172037d84dca3500def8c8b630657d1701f026f8af3f"},
+    {file = "pyflakes-3.3.2-py2.py3-none-any.whl", hash = "sha256:5039c8339cbb1944045f4ee5466908906180f13cc99cc9949348d10f82a5c32a"},
+    {file = "pyflakes-3.3.2.tar.gz", hash = "sha256:6dfd61d87b97fba5dcfaaf781171ac16be16453be6d816147989e7f6e6a9576b"},
 ]
 
 [[package]]
@@ -1187,26 +1187,26 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pylint"
-version = "3.3.4"
+version = "3.3.6"
 description = "python code static checker"
 optional = false
 python-versions = ">=3.9.0"
 groups = ["dev"]
 files = [
-    {file = "pylint-3.3.4-py3-none-any.whl", hash = "sha256:289e6a1eb27b453b08436478391a48cd53bb0efb824873f949e709350f3de018"},
-    {file = "pylint-3.3.4.tar.gz", hash = "sha256:74ae7a38b177e69a9b525d0794bd8183820bfa7eb68cc1bee6e8ed22a42be4ce"},
+    {file = "pylint-3.3.6-py3-none-any.whl", hash = "sha256:8b7c2d3e86ae3f94fb27703d521dd0b9b6b378775991f504d7c3a6275aa0a6a6"},
+    {file = "pylint-3.3.6.tar.gz", hash = "sha256:b634a041aac33706d56a0d217e6587228c66427e20ec21a019bc4cdee48c040a"},
 ]
 
 [package.dependencies]
-astroid = ">=3.3.8,<=3.4.0-dev0"
+astroid = ">=3.3.8,<=3.4.0.dev0"
 colorama = {version = ">=0.4.5", markers = "sys_platform == \"win32\""}
 dill = [
     {version = ">=0.3.7", markers = "python_version >= \"3.12\""},
     {version = ">=0.3.6", markers = "python_version == \"3.11\""},
 ]
-isort = ">=4.2.5,<5.13.0 || >5.13.0,<7"
+isort = ">=4.2.5,<5.13 || >5.13,<7"
 mccabe = ">=0.6,<0.8"
-platformdirs = ">=2.2.0"
+platformdirs = ">=2.2"
 tomlkit = ">=0.10.1"
 
 [package.extras]
@@ -1215,14 +1215,14 @@ testutils = ["gitpython (>3)"]
 
 [[package]]
 name = "pytest"
-version = "8.3.4"
+version = "8.3.5"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
 files = [
-    {file = "pytest-8.3.4-py3-none-any.whl", hash = "sha256:50e16d954148559c9a74109af1eaf0c945ba2d8f30f0a3d3335edde19788b6f6"},
-    {file = "pytest-8.3.4.tar.gz", hash = "sha256:965370d062bce11e73868e0335abac31b4d3de0e82f4007408d242b4f8610761"},
+    {file = "pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820"},
+    {file = "pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845"},
 ]
 
 [package.dependencies]
@@ -1255,14 +1255,14 @@ testing = ["coverage (>=6.2)", "hypothesis (>=5.7.1)"]
 
 [[package]]
 name = "python-keycloak"
-version = "5.3.1"
+version = "5.5.0"
 description = "python-keycloak is a Python package providing access to the Keycloak API."
 optional = false
 python-versions = "<4.0,>=3.9"
 groups = ["main"]
 files = [
-    {file = "python_keycloak-5.3.1-py3-none-any.whl", hash = "sha256:d3167d788add29d6cb3fda0629ee0f453fac9f6ee35241938488dbf9ac0635bb"},
-    {file = "python_keycloak-5.3.1.tar.gz", hash = "sha256:e4bbdbdddc480d64c6211095d633bea025028eb895aa83ccdc44f90ab70eff28"},
+    {file = "python_keycloak-5.5.0-py3-none-any.whl", hash = "sha256:325ada6c354703b58a944efe5cf711798459bf61e52cdd89b33aad30f07532b2"},
+    {file = "python_keycloak-5.5.0.tar.gz", hash = "sha256:f9485f694e2b8ad6f66d6ba79c1eaf6b5190050fcdd1175f0001403edfc1c357"},
 ]
 
 [package.dependencies]
@@ -1376,30 +1376,30 @@ requests = ">=2.0.1,<3.0.0"
 
 [[package]]
 name = "ruff"
-version = "0.9.6"
+version = "0.9.10"
 description = "An extremely fast Python linter and code formatter, written in Rust."
 optional = false
 python-versions = ">=3.7"
 groups = ["dev"]
 files = [
-    {file = "ruff-0.9.6-py3-none-linux_armv6l.whl", hash = "sha256:2f218f356dd2d995839f1941322ff021c72a492c470f0b26a34f844c29cdf5ba"},
-    {file = "ruff-0.9.6-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b908ff4df65dad7b251c9968a2e4560836d8f5487c2f0cc238321ed951ea0504"},
-    {file = "ruff-0.9.6-py3-none-macosx_11_0_arm64.whl", hash = "sha256:b109c0ad2ececf42e75fa99dc4043ff72a357436bb171900714a9ea581ddef83"},
-    {file = "ruff-0.9.6-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1de4367cca3dac99bcbd15c161404e849bb0bfd543664db39232648dc00112dc"},
-    {file = "ruff-0.9.6-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ac3ee4d7c2c92ddfdaedf0bf31b2b176fa7aa8950efc454628d477394d35638b"},
-    {file = "ruff-0.9.6-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5dc1edd1775270e6aa2386119aea692039781429f0be1e0949ea5884e011aa8e"},
-    {file = "ruff-0.9.6-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:4a091729086dffa4bd070aa5dab7e39cc6b9d62eb2bef8f3d91172d30d599666"},
-    {file = "ruff-0.9.6-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d1bbc6808bf7b15796cef0815e1dfb796fbd383e7dbd4334709642649625e7c5"},
-    {file = "ruff-0.9.6-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:589d1d9f25b5754ff230dce914a174a7c951a85a4e9270613a2b74231fdac2f5"},
-    {file = "ruff-0.9.6-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dc61dd5131742e21103fbbdcad683a8813be0e3c204472d520d9a5021ca8b217"},
-    {file = "ruff-0.9.6-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:5e2d9126161d0357e5c8f30b0bd6168d2c3872372f14481136d13de9937f79b6"},
-    {file = "ruff-0.9.6-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:68660eab1a8e65babb5229a1f97b46e3120923757a68b5413d8561f8a85d4897"},
-    {file = "ruff-0.9.6-py3-none-musllinux_1_2_i686.whl", hash = "sha256:c4cae6c4cc7b9b4017c71114115db0445b00a16de3bcde0946273e8392856f08"},
-    {file = "ruff-0.9.6-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:19f505b643228b417c1111a2a536424ddde0db4ef9023b9e04a46ed8a1cb4656"},
-    {file = "ruff-0.9.6-py3-none-win32.whl", hash = "sha256:194d8402bceef1b31164909540a597e0d913c0e4952015a5b40e28c146121b5d"},
-    {file = "ruff-0.9.6-py3-none-win_amd64.whl", hash = "sha256:03482d5c09d90d4ee3f40d97578423698ad895c87314c4de39ed2af945633caa"},
-    {file = "ruff-0.9.6-py3-none-win_arm64.whl", hash = "sha256:0e2bb706a2be7ddfea4a4af918562fdc1bcb16df255e5fa595bbd800ce322a5a"},
-    {file = "ruff-0.9.6.tar.gz", hash = "sha256:81761592f72b620ec8fa1068a6fd00e98a5ebee342a3642efd84454f3031dca9"},
+    {file = "ruff-0.9.10-py3-none-linux_armv6l.whl", hash = "sha256:eb4d25532cfd9fe461acc83498361ec2e2252795b4f40b17e80692814329e42d"},
+    {file = "ruff-0.9.10-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:188a6638dab1aa9bb6228a7302387b2c9954e455fb25d6b4470cb0641d16759d"},
+    {file = "ruff-0.9.10-py3-none-macosx_11_0_arm64.whl", hash = "sha256:5284dcac6b9dbc2fcb71fdfc26a217b2ca4ede6ccd57476f52a587451ebe450d"},
+    {file = "ruff-0.9.10-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:47678f39fa2a3da62724851107f438c8229a3470f533894b5568a39b40029c0c"},
+    {file = "ruff-0.9.10-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:99713a6e2766b7a17147b309e8c915b32b07a25c9efd12ada79f217c9c778b3e"},
+    {file = "ruff-0.9.10-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:524ee184d92f7c7304aa568e2db20f50c32d1d0caa235d8ddf10497566ea1a12"},
+    {file = "ruff-0.9.10-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:df92aeac30af821f9acf819fc01b4afc3dfb829d2782884f8739fb52a8119a16"},
+    {file = "ruff-0.9.10-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:de42e4edc296f520bb84954eb992a07a0ec5a02fecb834498415908469854a52"},
+    {file = "ruff-0.9.10-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d257f95b65806104b6b1ffca0ea53f4ef98454036df65b1eda3693534813ecd1"},
+    {file = "ruff-0.9.10-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b60dec7201c0b10d6d11be00e8f2dbb6f40ef1828ee75ed739923799513db24c"},
+    {file = "ruff-0.9.10-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:d838b60007da7a39c046fcdd317293d10b845001f38bcb55ba766c3875b01e43"},
+    {file = "ruff-0.9.10-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:ccaf903108b899beb8e09a63ffae5869057ab649c1e9231c05ae354ebc62066c"},
+    {file = "ruff-0.9.10-py3-none-musllinux_1_2_i686.whl", hash = "sha256:f9567d135265d46e59d62dc60c0bfad10e9a6822e231f5b24032dba5a55be6b5"},
+    {file = "ruff-0.9.10-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:5f202f0d93738c28a89f8ed9eaba01b7be339e5d8d642c994347eaa81c6d75b8"},
+    {file = "ruff-0.9.10-py3-none-win32.whl", hash = "sha256:bfb834e87c916521ce46b1788fbb8484966e5113c02df216680102e9eb960029"},
+    {file = "ruff-0.9.10-py3-none-win_amd64.whl", hash = "sha256:f2160eeef3031bf4b17df74e307d4c5fb689a6f3a26a2de3f7ef4044e3c484f1"},
+    {file = "ruff-0.9.10-py3-none-win_arm64.whl", hash = "sha256:5fd804c0327a5e5ea26615550e706942f348b197d5475ff34c19733aee4b2e69"},
+    {file = "ruff-0.9.10.tar.gz", hash = "sha256:9bacb735d7bada9cfb0f2c227d3658fc443d90a727b47f206fb33f52f3c0eac7"},
 ]
 
 [[package]]
@@ -1416,14 +1416,14 @@ files = [
 
 [[package]]
 name = "soupsieve"
-version = "2.6"
+version = "2.7"
 description = "A modern CSS selector implementation for Beautiful Soup."
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "soupsieve-2.6-py3-none-any.whl", hash = "sha256:e72c4ff06e4fb6e4b5a9f0f55fe6e81514581fca1515028625d0f299c602ccc9"},
-    {file = "soupsieve-2.6.tar.gz", hash = "sha256:e2e68417777af359ec65daac1057404a3c8a5455bb8abc36f1a9866ab1a51abb"},
+    {file = "soupsieve-2.7-py3-none-any.whl", hash = "sha256:6e60cc5c1ffaf1cebcc12e8188320b72071e922c2e897f737cadce79ad5d30c4"},
+    {file = "soupsieve-2.7.tar.gz", hash = "sha256:ad282f9b6926286d2ead4750552c8a6142bc4c783fd66b0293547c8fe6ae126a"},
 ]
 
 [[package]]
@@ -1495,26 +1495,41 @@ test = ["argcomplete (>=3.0.3)", "mypy (>=1.7.0)", "pre-commit", "pytest (>=7.0,
 
 [[package]]
 name = "typing-extensions"
-version = "4.12.2"
+version = "4.13.2"
 description = "Backported and Experimental Type Hints for Python 3.8+"
 optional = false
 python-versions = ">=3.8"
 groups = ["main", "dev"]
 files = [
-    {file = "typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d"},
-    {file = "typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"},
+    {file = "typing_extensions-4.13.2-py3-none-any.whl", hash = "sha256:a439e7c04b49fec3e5d3e2beaa21755cadbbdc391694e28ccdd36ca4a1408f8c"},
+    {file = "typing_extensions-4.13.2.tar.gz", hash = "sha256:e6c81219bd689f51865d9e372991c540bda33a0379d5573cddb9a3a23f7caaef"},
 ]
 
 [[package]]
+name = "typing-inspection"
+version = "0.4.0"
+description = "Runtime typing introspection tools"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "typing_inspection-0.4.0-py3-none-any.whl", hash = "sha256:50e72559fcd2a6367a19f7a7e610e6afcb9fac940c650290eed893d61386832f"},
+    {file = "typing_inspection-0.4.0.tar.gz", hash = "sha256:9765c87de36671694a67904bf2c96e395be9c6439bb6c87b5142569dcdd65122"},
+]
+
+[package.dependencies]
+typing-extensions = ">=4.12.0"
+
+[[package]]
 name = "urllib3"
-version = "2.3.0"
+version = "2.4.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "urllib3-2.3.0-py3-none-any.whl", hash = "sha256:1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df"},
-    {file = "urllib3-2.3.0.tar.gz", hash = "sha256:f8c5449b3cf0861679ce7e0503c7b44b5ec981bec0d1d3795a07f1ba96f0204d"},
+    {file = "urllib3-2.4.0-py3-none-any.whl", hash = "sha256:4e16665048960a0900c702d4a66415956a584919c03361cac9f1df5c5dd7e813"},
+    {file = "urllib3-2.4.0.tar.gz", hash = "sha256:414bc6535b787febd7567804cc015fee39daab8ad86268f1310a9250697de466"},
 ]
 
 [package.extras]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stellanow-sdk-python"
-version = "0.1.3-rc1"
+version = "0.1.4-rc1"
 description = "Welcome to the StellaNow Python SDK. This SDK is designed to provide an easy-to-use interface for developers integrating their Python applications with the StellaNow Platform. The SDK communicates with the StellaNow Platform using the MQTT."
 authors = [
     {name = "Stella Systems",email = "help@stella.systems"}
@@ -59,6 +59,10 @@ lint-check = { sequence = [
     { ref = "lint-isort-check" },
 ]}
 test = "pytest"
+
+[tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "function"
+asyncio_mode = "auto"
 
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stellanow-sdk-python"
-version = "0.1.4-rc1"
+version = "0.1.4"
 description = "Welcome to the StellaNow Python SDK. This SDK is designed to provide an easy-to-use interface for developers integrating their Python applications with the StellaNow Platform. The SDK communicates with the StellaNow Platform using the MQTT."
 authors = [
     {name = "Stella Systems",email = "help@stella.systems"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stellanow-sdk-python"
-version = "0.1.3"
+version = "0.1.3-rc1"
 description = "Welcome to the StellaNow Python SDK. This SDK is designed to provide an easy-to-use interface for developers integrating their Python applications with the StellaNow Platform. The SDK communicates with the StellaNow Platform using the MQTT."
 authors = [
     {name = "Stella Systems",email = "help@stella.systems"}

--- a/stellanow_sdk_python/authentication/auth_service.py
+++ b/stellanow_sdk_python/authentication/auth_service.py
@@ -22,7 +22,7 @@ IN THE SOFTWARE.
 
 import asyncio
 from datetime import datetime, timedelta
-from typing import Any, Dict, Optional
+from typing import Any, Callable, Dict, Optional
 
 from keycloak import KeycloakOpenID
 from keycloak.exceptions import KeycloakError
@@ -44,7 +44,7 @@ class StellaNowAuthenticationService:
         self.keycloak_openid = KeycloakOpenID(
             server_url=env_config.authority,
             client_id=credentials.client_id,
-            realm_name=project_info.organization_id,
+            realm_name=str(project_info.organization_id),
             verify=True,
         )
         self.project_info = project_info
@@ -53,11 +53,18 @@ class StellaNowAuthenticationService:
         self.token_expires: Optional[datetime] = None
         self.lock = asyncio.Lock()
         self._refresh_task: Optional[asyncio.Task[None]] = None
+        self._token_update_callbacks: list[Callable[[str], Any]] = []  # Callbacks for token updates
+
+    def register_token_update_callback(self, callback: Callable[[str], Any]) -> None:
+        """Register a callback to be called when the token is refreshed."""
+        self._token_update_callbacks.append(callback)
+        logger.debug("Registered token update callback")
 
     async def start_refresh_task(self) -> None:
         """Start a background task to refresh the token periodically."""
         if self._refresh_task is None:
             self._refresh_task = asyncio.create_task(self._auto_refresh())
+            logger.info("Started token refresh task.")
 
     async def stop_refresh_task(self) -> None:
         """Stop the token refresh task."""
@@ -66,14 +73,17 @@ class StellaNowAuthenticationService:
             try:
                 await self._refresh_task
             except asyncio.CancelledError:
-                pass
+                logger.info("Token refresh task cancelled.")
             self._refresh_task = None
 
     async def _auto_refresh(self) -> None:
         """Periodically refresh the token before it expires."""
         while True:
             if self.token_response and self.token_expires and not self._is_token_expired():
-                expires_in = (self.token_expires - datetime.now()).total_seconds()  # Null check added
+                logger.debug("In _auto_refresh loop")
+                logger.debug(f"Token expired: {self._is_token_expired()}")
+                logger.debug(f"Token expires at: {self.token_expires}")
+                expires_in = (self.token_expires - datetime.now()).total_seconds()
                 await asyncio.sleep(max(expires_in - 30, 1))
             else:
                 logger.debug("No valid token to refresh, attempting initial authentication.")
@@ -82,7 +92,10 @@ class StellaNowAuthenticationService:
                 await self.refresh_access_token()
             except Exception as e:
                 logger.error(f"Failed to auto-refresh token: {e}")
-                await asyncio.sleep(60)
+                if self._is_token_expired():
+                    logger.warning("Token is expired, retrying immediately.")
+                    continue
+                await asyncio.sleep(15)
 
     async def authenticate(self) -> str:
         """Authenticate and get the access token asynchronously."""
@@ -102,6 +115,8 @@ class StellaNowAuthenticationService:
                 self.token_response = token_response
                 self.token_expires = self._calculate_token_expires_time(self.token_response)
                 logger.info("Authentication successful!")
+                logger.debug(f"Token expires_in: {token_response.get('expires_in')}, expires at: {self.token_expires}")
+                await self.start_refresh_task()
                 return self.token_response["access_token"]
             except KeycloakError as e:
                 error_status = getattr(e, "response_code", "Unknown")
@@ -122,7 +137,7 @@ class StellaNowAuthenticationService:
 
     def _is_token_expired(self) -> bool:
         if self.token_expires is None:
-            return True  # Treat as expired if not set
+            return True
         return datetime.now() >= self.token_expires
 
     async def get_access_token(self) -> str:
@@ -143,6 +158,15 @@ class StellaNowAuthenticationService:
                 self.token_response = await self.keycloak_openid.a_refresh_token(refresh_token)
                 self.token_expires = self._calculate_token_expires_time(self.token_response)
                 logger.info("Access token refreshed successfully.")
+                logger.debug(
+                    f"Refreshed token: {self.token_response['access_token'][:20]}..., expires: {self.token_expires}"
+                )
+                # Notify callbacks of new token
+                for callback in self._token_update_callbacks:
+                    try:
+                        await callback(self.token_response["access_token"])
+                    except Exception as e:
+                        logger.error(f"Token update callback failed: {e}")
                 assert self.token_response is not None
                 return self.token_response["access_token"]
             except KeycloakError as e:

--- a/stellanow_sdk_python/authentication/auth_service.py
+++ b/stellanow_sdk_python/authentication/auth_service.py
@@ -157,18 +157,17 @@ class StellaNowAuthenticationService:
                 logger.info("Refreshing access token...")
                 self.token_response = await self.keycloak_openid.a_refresh_token(refresh_token)
                 self.token_expires = self._calculate_token_expires_time(self.token_response)
+                access_token: str = self.token_response["access_token"]
                 logger.info("Access token refreshed successfully.")
-                logger.debug(
-                    f"Refreshed token: {self.token_response['access_token'][:20]}..., expires: {self.token_expires}"
-                )
+                logger.debug(f"Refreshed token: {access_token[:20]}..., expires: {self.token_expires}")
                 # Notify callbacks of new token
                 for callback in self._token_update_callbacks:
                     try:
-                        await callback(self.token_response["access_token"])
+                        await callback(access_token)
                     except Exception as e:
                         logger.error(f"Token update callback failed: {e}")
                 assert self.token_response is not None
-                return self.token_response["access_token"]
+                return access_token
             except KeycloakError as e:
                 logger.error(f"Failed to refresh access token: {e}")
                 raise Exception("Failed to refresh access token")

--- a/stellanow_sdk_python/config/enums/auth_strategy.py
+++ b/stellanow_sdk_python/config/enums/auth_strategy.py
@@ -20,26 +20,10 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 IN THE SOFTWARE.
 """
 
-from uuid import UUID
-
-from stellanow_sdk_python.config.read_env import read_env_uuid
+from enum import Enum
 
 
-class StellaProjectInfo:
-    """Holds organization and project identifiers for the StellaNow SDK."""
-
-    def __init__(self, organization_id: UUID, project_id: UUID):
-        self.organization_id = organization_id
-        self.project_id = project_id
-
-    @classmethod
-    def from_env(cls) -> "StellaProjectInfo":
-        return cls(
-            organization_id=read_env_uuid("ORGANIZATION_ID"),
-            project_id=read_env_uuid("PROJECT_ID"),
-        )
-
-
-def project_info_from_env() -> StellaProjectInfo:
-    """Create a StellaProjectInfo instance from environment variables."""
-    return StellaProjectInfo.from_env()
+class AuthStrategyTypes(Enum):
+    OIDC = "oidc"
+    USERNAME_PASS = "username_password"
+    NO_AUTH = "none"

--- a/stellanow_sdk_python/config/enums/auth_strategy.py
+++ b/stellanow_sdk_python/config/enums/auth_strategy.py
@@ -25,5 +25,5 @@ from enum import Enum
 
 class AuthStrategyTypes(Enum):
     OIDC = "oidc"
-    USERNAME_PASS = "username_password"
+    BASIC = "basic"
     NO_AUTH = "none"

--- a/stellanow_sdk_python/config/enums/logger_config.py
+++ b/stellanow_sdk_python/config/enums/logger_config.py
@@ -20,26 +20,14 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 IN THE SOFTWARE.
 """
 
-from uuid import UUID
-
-from stellanow_sdk_python.config.read_env import read_env_uuid
+from enum import Enum
 
 
-class StellaProjectInfo:
-    """Holds organization and project identifiers for the StellaNow SDK."""
+class LoggerLevel(Enum):
+    """Enum for loguru logger levels."""
 
-    def __init__(self, organization_id: UUID, project_id: UUID):
-        self.organization_id = organization_id
-        self.project_id = project_id
-
-    @classmethod
-    def from_env(cls) -> "StellaProjectInfo":
-        return cls(
-            organization_id=read_env_uuid("ORGANIZATION_ID"),
-            project_id=read_env_uuid("PROJECT_ID"),
-        )
-
-
-def project_info_from_env() -> StellaProjectInfo:
-    """Create a StellaProjectInfo instance from environment variables."""
-    return StellaProjectInfo.from_env()
+    DEBUG = "DEBUG"
+    INFO = "INFO"
+    SUCCESS = "SUCCESS"
+    WARNING = "WARNING"
+    ERROR = "ERROR"

--- a/stellanow_sdk_python/config/read_env.py
+++ b/stellanow_sdk_python/config/read_env.py
@@ -22,6 +22,7 @@ IN THE SOFTWARE.
 
 import os
 from typing import Optional
+from uuid import UUID
 
 from loguru import logger
 
@@ -45,3 +46,24 @@ def read_env(name: str, missing: Optional[str] = None) -> str:
         logger.error(f"Required environment variable '{name}' is not set")
         raise ValueError(f"Required environment variable '{name}' is not set")
     return value
+
+
+def read_env_uuid(name: str) -> UUID:
+    """
+    Read an environment variable and ensure it is a valid UUID.
+
+    Args:
+        name (str): The name of the environment variable.
+
+    Returns:
+        UUID: The UUID value of the environment variable.
+
+    Raises:
+        ValueError: If the environment variable is not set or is not a valid UUID.
+    """
+    value = read_env(name)
+    try:
+        return UUID(value)
+    except ValueError:
+        logger.error(f"Environment variable '{name}' with value '{value}' is not a valid UUID")
+        raise ValueError(f"Environment variable '{name}' with value '{value}' is not a valid UUID")

--- a/stellanow_sdk_python/config/stellanow_auth_credentials.py
+++ b/stellanow_sdk_python/config/stellanow_auth_credentials.py
@@ -26,6 +26,8 @@ from typing import Dict, Optional
 from pydantic import BaseModel
 from typing_extensions import TypedDict
 
+from stellanow_sdk_python.config.enums.auth_strategy import AuthStrategyTypes
+
 DEFAULT_OIDC_CLIENT_ID = "event-ingestor"
 
 
@@ -39,16 +41,16 @@ class CredentialFieldMapping(TypedDict):
 
 # Define config outside the class to avoid Pydantic interference
 STRATEGY_CONFIG: Dict[str, list[CredentialFieldMapping]] = {
-    "oidc": [
+    AuthStrategyTypes.OIDC.value: [
         {"env_var": "OIDC_USERNAME", "field": "username", "required": True},
         {"env_var": "OIDC_PASSWORD", "field": "password", "required": True},
         {"env_var": "OIDC_CLIENT_ID", "field": "client_id", "required": False},
     ],
-    "username_password": [
+    AuthStrategyTypes.BASIC.value: [
         {"env_var": "MQTT_USERNAME", "field": "username", "required": True},
         {"env_var": "MQTT_PASSWORD", "field": "password", "required": True},
     ],
-    "none": [],
+    AuthStrategyTypes.NO_AUTH.value: [],
 }
 
 

--- a/stellanow_sdk_python/config/stellanow_auth_credentials.py
+++ b/stellanow_sdk_python/config/stellanow_auth_credentials.py
@@ -21,19 +21,12 @@ IN THE SOFTWARE.
 """
 
 import os
-from enum import Enum
 from typing import Dict, Optional
 
 from pydantic import BaseModel
 from typing_extensions import TypedDict
 
 DEFAULT_OIDC_CLIENT_ID = "event-ingestor"
-
-
-class AuthStrategyTypes(Enum):
-    OIDC = "oidc"
-    USERNAME_PASS = "username_password"
-    NO_AUTH = "none"
 
 
 class CredentialFieldMapping(TypedDict):

--- a/stellanow_sdk_python/configure_sdk.py
+++ b/stellanow_sdk_python/configure_sdk.py
@@ -51,7 +51,7 @@ def configure_sdk(
     Generic method to configure and return a StellaNowSDK instance.
 
     Args:
-        auth_strategy_type (str): Authentication strategy ("oidc", "username_password", "none").
+        auth_strategy_type (str): Authentication strategy ("oidc", "basic", "none").
         env_config (StellaNowEnvironmentConfig): Environment configuration (e.g., from EnvConfig).
         queue_strategy_type (str, optional): Queue strategy ("fifo" or "lifo"). Defaults to "fifo".
         logger_level (LoggerLevel, optional): Logging level for the SDK. Defaults to LoggerLevel.INFO.
@@ -124,34 +124,34 @@ def configure_dev_no_auth_mqtt_fifo_sdk(logger_level: LoggerLevel = LoggerLevel.
     )
 
 
-def configure_dev_username_password_mqtt_lifo_sdk(logger_level: LoggerLevel = LoggerLevel.INFO) -> StellaNowSDK:
-    """Configure SDK for stellanow_dev env with username/password auth, MQTT sink, and LIFO queue."""
+def configure_dev_basic_mqtt_lifo_sdk(logger_level: LoggerLevel = LoggerLevel.INFO) -> StellaNowSDK:
+    """Configure SDK for stellanow_dev env with basic auth, MQTT sink, and LIFO queue."""
     return configure_sdk(
-        auth_strategy_type=AuthStrategyTypes.USERNAME_PASS.value,
+        auth_strategy_type=AuthStrategyTypes.BASIC.value,
         env_config=EnvConfig.stellanow_dev(),
         queue_strategy_type=MessageQueueType.LIFO.value,
         logger_level=logger_level,
     )
 
 
-def configure_local_nanomq_username_password_mqtt_fifo_sdk(
+def configure_local_nanomq_basic_mqtt_fifo_sdk(
     logger_level: LoggerLevel = LoggerLevel.INFO,
 ) -> StellaNowSDK:
-    """Configure SDK for local NanoMQ env with username/password auth, MQTT sink, and FIFO queue."""
+    """Configure SDK for local NanoMQ env with basic auth, MQTT sink, and FIFO queue."""
     return configure_sdk(
-        auth_strategy_type=AuthStrategyTypes.USERNAME_PASS.value,
+        auth_strategy_type=AuthStrategyTypes.BASIC.value,
         env_config=EnvConfig.nanomq_local(),
         queue_strategy_type=MessageQueueType.FIFO.value,
         logger_level=logger_level,
     )
 
 
-def configure_local_nanomq_username_password_mqtt_lifo_sdk(
+def configure_local_nanomq_basic_mqtt_lifo_sdk(
     logger_level: LoggerLevel = LoggerLevel.INFO,
 ) -> StellaNowSDK:
-    """Configure SDK for local NanoMQ env with username/password auth, MQTT sink, and LIFO queue."""
+    """Configure SDK for local NanoMQ env with basic auth, MQTT sink, and LIFO queue."""
     return configure_sdk(
-        auth_strategy_type=AuthStrategyTypes.USERNAME_PASS.value,
+        auth_strategy_type=AuthStrategyTypes.BASIC.value,
         env_config=EnvConfig.nanomq_local(),
         queue_strategy_type=MessageQueueType.LIFO.value,
         logger_level=logger_level,
@@ -178,10 +178,10 @@ def configure_prod_no_auth_mqtt_fifo_sdk(logger_level: LoggerLevel = LoggerLevel
     )
 
 
-def configure_prod_username_password_mqtt_fifo_sdk(logger_level: LoggerLevel = LoggerLevel.INFO) -> StellaNowSDK:
-    """Configure SDK for stellanow_prod env with username/password auth, MQTT sink, and FIFO queue."""
+def configure_prod_basic_mqtt_fifo_sdk(logger_level: LoggerLevel = LoggerLevel.INFO) -> StellaNowSDK:
+    """Configure SDK for stellanow_prod env with basic auth, MQTT sink, and FIFO queue."""
     return configure_sdk(
-        auth_strategy_type=AuthStrategyTypes.USERNAME_PASS.value,
+        auth_strategy_type=AuthStrategyTypes.BASIC.value,
         env_config=EnvConfig.stellanow_prod(),
         queue_strategy_type=MessageQueueType.FIFO.value,
         logger_level=logger_level,

--- a/stellanow_sdk_python/configure_sdk.py
+++ b/stellanow_sdk_python/configure_sdk.py
@@ -25,6 +25,8 @@ import sys
 from loguru import logger
 
 from stellanow_sdk_python.config.eniviroment_config.stellanow_env_config import EnvConfig, StellaNowEnvironmentConfig
+from stellanow_sdk_python.config.enums.auth_strategy import AuthStrategyTypes
+from stellanow_sdk_python.config.enums.logger_config import LoggerLevel
 from stellanow_sdk_python.config.stellanow_auth_credentials import StellaNowCredentials
 from stellanow_sdk_python.config.stellanow_config import project_info_from_env
 from stellanow_sdk_python.message_queue.message_queue_strategy.fifo_message_queue_strategy import (
@@ -43,6 +45,7 @@ def configure_sdk(
     auth_strategy_type: str,
     env_config: StellaNowEnvironmentConfig,
     queue_strategy_type: str = MessageQueueType.FIFO.value,
+    logger_level: LoggerLevel = LoggerLevel.INFO,
 ) -> StellaNowSDK:
     """
     Generic method to configure and return a StellaNowSDK instance.
@@ -50,7 +53,8 @@ def configure_sdk(
     Args:
         auth_strategy_type (str): Authentication strategy ("oidc", "username_password", "none").
         env_config (StellaNowEnvironmentConfig): Environment configuration (e.g., from EnvConfig).
-        queue_strategy_type (str, optional): Queue strategy ("fifo" and "lifo" currently supported). Defaults to "fifo".
+        queue_strategy_type (str, optional): Queue strategy ("fifo" or "lifo"). Defaults to "fifo".
+        logger_level (LoggerLevel, optional): Logging level for the SDK. Defaults to LoggerLevel.INFO.
 
     Returns:
         StellaNowSDK: A configured SDK instance.
@@ -60,7 +64,7 @@ def configure_sdk(
     """
     try:
         logger.remove()
-        logger.add(sys.stderr, level="INFO")
+        logger.add(sys.stderr, level=logger_level.value)
         logger.info("Starting StellaNow SDK demo...")
 
         # Load project info
@@ -100,53 +104,85 @@ def configure_sdk(
 
 
 # Pre-defined configurations
-def configure_dev_oidc_mqtt_fifo_sdk() -> StellaNowSDK:
+def configure_dev_oidc_mqtt_fifo_sdk(logger_level: LoggerLevel = LoggerLevel.INFO) -> StellaNowSDK:
     """Configure SDK for stellanow_dev env with OIDC auth, MQTT sink, and FIFO queue."""
     return configure_sdk(
-        auth_strategy_type="oidc", env_config=EnvConfig.stellanow_dev(), queue_strategy_type=MessageQueueType.FIFO.value
+        auth_strategy_type=AuthStrategyTypes.OIDC.value,
+        env_config=EnvConfig.stellanow_dev(),
+        queue_strategy_type=MessageQueueType.FIFO.value,
+        logger_level=logger_level,
     )
 
 
-def configure_dev_username_password_mqtt_lifo_sdk() -> StellaNowSDK:
-    """Configure SDK for stellanow_dev env with username/password auth, MQTT sink, and FIFO queue."""
+def configure_dev_no_auth_mqtt_fifo_sdk(logger_level: LoggerLevel = LoggerLevel.INFO) -> StellaNowSDK:
+    """Configure SDK for stellanow_dev env with NO auth, MQTT sink, and FIFO queue."""
     return configure_sdk(
-        auth_strategy_type="username_password",
+        auth_strategy_type=AuthStrategyTypes.NO_AUTH.value,
+        env_config=EnvConfig.stellanow_dev(),
+        queue_strategy_type=MessageQueueType.FIFO.value,
+        logger_level=logger_level,
+    )
+
+
+def configure_dev_username_password_mqtt_lifo_sdk(logger_level: LoggerLevel = LoggerLevel.INFO) -> StellaNowSDK:
+    """Configure SDK for stellanow_dev env with username/password auth, MQTT sink, and LIFO queue."""
+    return configure_sdk(
+        auth_strategy_type=AuthStrategyTypes.USERNAME_PASS.value,
         env_config=EnvConfig.stellanow_dev(),
         queue_strategy_type=MessageQueueType.LIFO.value,
+        logger_level=logger_level,
     )
 
 
-def configure_local_nanomq_username_password_mqtt_fifo_sdk() -> StellaNowSDK:
-    """Configure SDK for stellanow_dev env with username/password auth, MQTT sink, and FIFO queue."""
+def configure_local_nanomq_username_password_mqtt_fifo_sdk(
+    logger_level: LoggerLevel = LoggerLevel.INFO,
+) -> StellaNowSDK:
+    """Configure SDK for local NanoMQ env with username/password auth, MQTT sink, and FIFO queue."""
     return configure_sdk(
-        auth_strategy_type="username_password",
+        auth_strategy_type=AuthStrategyTypes.USERNAME_PASS.value,
         env_config=EnvConfig.nanomq_local(),
         queue_strategy_type=MessageQueueType.FIFO.value,
+        logger_level=logger_level,
     )
 
 
-def configure_local_nanomq_username_password_mqtt_lifo_sdk() -> StellaNowSDK:
-    """Configure SDK for stellanow_dev env with username/password auth, MQTT sink, and FIFO queue."""
+def configure_local_nanomq_username_password_mqtt_lifo_sdk(
+    logger_level: LoggerLevel = LoggerLevel.INFO,
+) -> StellaNowSDK:
+    """Configure SDK for local NanoMQ env with username/password auth, MQTT sink, and LIFO queue."""
     return configure_sdk(
-        auth_strategy_type="username_password",
+        auth_strategy_type=AuthStrategyTypes.USERNAME_PASS.value,
         env_config=EnvConfig.nanomq_local(),
         queue_strategy_type=MessageQueueType.LIFO.value,
+        logger_level=logger_level,
     )
 
 
-def configure_prod_none_mqtt_fifo_sdk() -> StellaNowSDK:
-    """Configure SDK for stellanow_prod env with no auth, MQTT sink, and FIFO queue."""
+def configure_prod_oidc_mqtt_fifo_sdk(logger_level: LoggerLevel = LoggerLevel.INFO) -> StellaNowSDK:
+    """Configure SDK for stellanow_prod env with OIDC auth, MQTT sink, and FIFO queue."""
     return configure_sdk(
-        auth_strategy_type="none",
+        auth_strategy_type=AuthStrategyTypes.OIDC.value,
         env_config=EnvConfig.stellanow_prod(),
         queue_strategy_type=MessageQueueType.FIFO.value,
+        logger_level=logger_level,
     )
 
 
-# Optional: Add more variants if you have LIFO or other strategies
-# def configure_dev_oidc_mqtt_lifo_sdk() -> StellaNowSDK:
-#     return configure_sdk(
-#         auth_strategy_type="oidc",
-#         env_config=EnvConfig.stellanow_dev(),
-#         queue_strategy_type="lifo"
-#     )
+def configure_prod_no_auth_mqtt_fifo_sdk(logger_level: LoggerLevel = LoggerLevel.INFO) -> StellaNowSDK:
+    """Configure SDK for stellanow_prod env with no auth, MQTT sink, and FIFO queue."""
+    return configure_sdk(
+        auth_strategy_type=AuthStrategyTypes.NO_AUTH.value,
+        env_config=EnvConfig.stellanow_prod(),
+        queue_strategy_type=MessageQueueType.FIFO.value,
+        logger_level=logger_level,
+    )
+
+
+def configure_prod_username_password_mqtt_fifo_sdk(logger_level: LoggerLevel = LoggerLevel.INFO) -> StellaNowSDK:
+    """Configure SDK for stellanow_prod env with username/password auth, MQTT sink, and FIFO queue."""
+    return configure_sdk(
+        auth_strategy_type=AuthStrategyTypes.USERNAME_PASS.value,
+        env_config=EnvConfig.stellanow_prod(),
+        queue_strategy_type=MessageQueueType.FIFO.value,
+        logger_level=logger_level,
+    )

--- a/stellanow_sdk_python/message_queue/message_queue.py
+++ b/stellanow_sdk_python/message_queue/message_queue.py
@@ -85,7 +85,6 @@ class StellaNowMessageQueue:
                     logger.debug(f"Dequeued message {message.message_id}, Queue size: {self.get_message_count()}")
                     await self._send_message_to_sink(message)
             else:
-                logger.debug("No messages in queue, waiting briefly...")
                 await asyncio.sleep(0.1)
 
     async def _send_message_to_sink(self, message: StellaNowEventWrapper) -> None:

--- a/stellanow_sdk_python/messages/event.py
+++ b/stellanow_sdk_python/messages/event.py
@@ -21,18 +21,23 @@ IN THE SOFTWARE.
 """
 
 from typing import Optional
+from uuid import UUID
 
-from pydantic import Field
+from pydantic import Field, field_serializer
 
 from stellanow_sdk_python.messages.base import StellaNowBaseModel
 from stellanow_sdk_python.messages.message import Entity, StellaNowMessageWrapper
 
 
 class EventKey(StellaNowBaseModel):
-    organization_id: str = Field(..., serialization_alias="organizationId")
-    project_id: str = Field(..., serialization_alias="projectId")
+    organization_id: UUID = Field(..., serialization_alias="organizationId")
+    project_id: UUID = Field(..., serialization_alias="projectId")
     entity_id: str = Field(..., serialization_alias="entityId")
     entity_type_definition_id: str = Field(..., serialization_alias="entityTypeDefinitionId")
+
+    @field_serializer("organization_id", "project_id")
+    def serialize_uuid(self, value: UUID) -> str:
+        return str(value)
 
 
 class StellaNowEventWrapper(StellaNowBaseModel):
@@ -44,7 +49,9 @@ class StellaNowEventWrapper(StellaNowBaseModel):
         return self.value.message_id
 
     @classmethod
-    def create(cls, message: StellaNowMessageWrapper, organization_id: str, project_id: str) -> "StellaNowEventWrapper":
+    def create(
+        cls, message: StellaNowMessageWrapper, organization_id: UUID, project_id: UUID
+    ) -> "StellaNowEventWrapper":
         entity: Entity = message.primary_entity
 
         return cls(

--- a/stellanow_sdk_python/messages/message.py
+++ b/stellanow_sdk_python/messages/message.py
@@ -1,9 +1,9 @@
 import json
 import uuid
 from datetime import UTC, datetime
-from typing import List, Optional
+from typing import Any, Dict, List, Optional, Union
 
-from pydantic import Field
+from pydantic import Field, PrivateAttr
 
 from stellanow_sdk_python.messages.base import StellaNowBaseModel
 
@@ -27,6 +27,40 @@ class Metadata(StellaNowBaseModel):
 class StellaNowMessageBase(StellaNowBaseModel):
     event_name: str = Field(exclude=True)
     entities: List[Entity] = Field(exclude=True)
+    _message_origin_date_utc: Optional[datetime] = PrivateAttr(default=None)
+
+    def __init__(self, **data: Dict[str, Any]) -> None:
+        # Handle message_origin_date_utc during initialization
+        message_origin_date_utc = data.pop("message_origin_date_utc", None)
+        super().__init__(**data)
+        if message_origin_date_utc is not None:
+            self.message_origin_date_utc = message_origin_date_utc
+
+    @classmethod
+    def _validate_timestamp(cls, value: Union[datetime, str]) -> datetime:
+        if isinstance(value, datetime):
+            return value
+        if isinstance(value, str):
+            try:
+                if not value.endswith("Z"):
+                    raise ValueError("Timestamp must end with 'Z'")
+                if "." not in value.split("T")[1]:
+                    raise ValueError("Timestamp must be in ISO 8601 format with microseconds")
+                return datetime.fromisoformat(value.replace("Z", "+00:00"))
+            except ValueError as e:
+                raise ValueError(f"Invalid timestamp format: {str(e)}")
+        raise ValueError("message_origin_date_utc must be a datetime object or a string")
+
+    @property
+    def message_origin_date_utc(self) -> Optional[datetime]:
+        return self._message_origin_date_utc
+
+    @message_origin_date_utc.setter
+    def message_origin_date_utc(self, value: Optional[Union[datetime, str]]) -> None:
+        if value is None:
+            self._message_origin_date_utc = None
+        else:
+            self._message_origin_date_utc = self._validate_timestamp(value)
 
 
 class StellaNowMessageWrapper(StellaNowBaseModel):
@@ -42,21 +76,29 @@ class StellaNowMessageWrapper(StellaNowBaseModel):
         return self.metadata.entities[0]
 
     @classmethod
-    def create(cls, message: StellaNowMessageBase) -> "StellaNowMessageWrapper":
+    def create(
+        cls,
+        message: StellaNowMessageBase,
+    ) -> "StellaNowMessageWrapper":
         return cls.create_raw(
             event_type_definition_id=message.event_name,
             entity_types=message.entities,
             message_json=json.dumps(message.model_dump(by_alias=True)),
+            message_origin_date_utc=message.message_origin_date_utc,
         )
 
     @classmethod
     def create_raw(
-        cls, event_type_definition_id: str, entity_types: List[Entity], message_json: str
+        cls,
+        event_type_definition_id: str,
+        entity_types: List[Entity],
+        message_json: str,
+        message_origin_date_utc: Optional[datetime] = None,
     ) -> "StellaNowMessageWrapper":
         return StellaNowMessageWrapper(
             metadata=Metadata(
                 message_id=str(uuid.uuid4()),
-                message_origin_date_utc=datetime.now(UTC),
+                message_origin_date_utc=message_origin_date_utc or datetime.now(UTC),
                 event_type_definition_id=event_type_definition_id,
                 entity_type_ids=entity_types,
             ),

--- a/stellanow_sdk_python/sinks/mqtt/auth_strategy/auth_factory.py
+++ b/stellanow_sdk_python/sinks/mqtt/auth_strategy/auth_factory.py
@@ -24,7 +24,7 @@ def create_auth_strategy(
     Create an authentication strategy based on the specified type.
 
     Args:
-        auth_strategy_type (str): The type of authentication ("oidc", "username_password", "none").
+        auth_strategy_type (str): The type of authentication ("oidc", "basic", "none").
         project_info (StellaProjectInfo): Project information including organization_id.
         credentials (StellaNowCredentials): The credentials object containing auth details.
         env_config (StellaNowEnvironmentConfig): The environment configuration.
@@ -42,7 +42,7 @@ def create_auth_strategy(
     logger.info(f"Creating auth strategy: {auth_strategy_type}")
     if auth_strategy_type == AuthStrategyTypes.OIDC.value:
         return OidcMqttAuthStrategy(project_info, credentials, env_config)
-    elif auth_strategy_type == AuthStrategyTypes.USERNAME_PASS.value:
+    elif auth_strategy_type == AuthStrategyTypes.BASIC.value:
         return UserPassAuthMqttAuthStrategy(credentials)
     elif auth_strategy_type == AuthStrategyTypes.NO_AUTH.value:
         return NoAuthMqttAuthStrategy()

--- a/stellanow_sdk_python/sinks/mqtt/auth_strategy/auth_factory.py
+++ b/stellanow_sdk_python/sinks/mqtt/auth_strategy/auth_factory.py
@@ -5,7 +5,8 @@ Factory for creating MQTT authentication strategies.
 from loguru import logger
 
 from stellanow_sdk_python.config.eniviroment_config.stellanow_env_config import StellaNowEnvironmentConfig
-from stellanow_sdk_python.config.stellanow_auth_credentials import AuthStrategyTypes, StellaNowCredentials
+from stellanow_sdk_python.config.enums.auth_strategy import AuthStrategyTypes
+from stellanow_sdk_python.config.stellanow_auth_credentials import StellaNowCredentials
 from stellanow_sdk_python.config.stellanow_config import StellaProjectInfo
 from stellanow_sdk_python.sinks.mqtt.auth_strategy.i_mqtt_auth_strategy import IMqttAuthStrategy
 from stellanow_sdk_python.sinks.mqtt.auth_strategy.no_auth_mqtt_auth_strategy import NoAuthMqttAuthStrategy

--- a/stellanow_sdk_python_demo/main.py
+++ b/stellanow_sdk_python_demo/main.py
@@ -49,9 +49,7 @@ from stellanow_sdk_python_demo.messages.user_details_update_message import UserD
 
 async def main():
     """Main entry point for the StellaNow SDK demo."""
-    # sdk = configure_local_nanomq_username_password_mqtt_lifo_sdk()
     sdk = configure_dev_oidc_mqtt_fifo_sdk()
-    # sdk = configure_dev_username_password_mqtt_lifo_sdk()
     shutdown_event = asyncio.Event()  # Event to signal shutdown
 
     try:

--- a/tests/test_stellanow_user_details_update_message.py
+++ b/tests/test_stellanow_user_details_update_message.py
@@ -1,0 +1,91 @@
+from datetime import UTC, datetime
+
+import pytest
+
+from stellanow_sdk_python_demo.messages.models.phone_number_model import PhoneNumberModel
+from stellanow_sdk_python_demo.messages.user_details_update_message import UserDetailsUpdateMessage
+
+
+@pytest.fixture
+def phone_number_model() -> PhoneNumberModel:
+    """Fixture providing a PhoneNumberModel instance."""
+    return PhoneNumberModel(country_code=48, number=700000)
+
+
+def test_user_details_update_message_valid_cases(phone_number_model: PhoneNumberModel):
+    """Test valid cases for message_origin_date_utc."""
+    patron = "patron_123"
+    user_id = "user_456"
+
+    # Test with valid ISO 8601 string
+    message_with_iso = UserDetailsUpdateMessage(
+        patron=patron,
+        user_id=user_id,
+        phone_number=phone_number_model,
+    )
+    message_with_iso.message_origin_date_utc = "2025-04-10T22:15:10.975368Z"
+    assert isinstance(message_with_iso.message_origin_date_utc, datetime)
+    expected_dt = datetime.fromisoformat("2025-04-10T22:15:10.975368+00:00")
+    assert message_with_iso.message_origin_date_utc == expected_dt
+
+    # Test with valid datetime
+    valid_dt = datetime.now(UTC)
+    message_with_dt = UserDetailsUpdateMessage(
+        patron=patron,
+        user_id=user_id,
+        phone_number=phone_number_model,
+    )
+    message_with_dt.message_origin_date_utc = valid_dt
+    assert message_with_dt.message_origin_date_utc == valid_dt
+
+    # Test without message_origin_date_utc
+    message_without_date = UserDetailsUpdateMessage(
+        patron=patron,
+        user_id=user_id,
+        phone_number=phone_number_model,
+    )
+    assert message_without_date.message_origin_date_utc is None
+
+
+def test_user_details_update_message_invalid_timestamps(phone_number_model: PhoneNumberModel):
+    """Test invalid message_origin_date_utc values."""
+    patron = "patron_123"
+    user_id = "user_456"
+
+    # Create message first
+    message = UserDetailsUpdateMessage(
+        patron=patron,
+        user_id=user_id,
+        phone_number=phone_number_model,
+    )
+
+    # Test invalid formats
+    test_cases = [
+        ("2025-04-10T22:15:10Z", "must be in ISO 8601 format with microseconds"),  # Missing microseconds
+        ("2025-04-10T22:15:10.975368", "must end with 'Z'"),  # Missing Z suffix
+        ("not-a-datetime", "Invalid timestamp format"),  # Malformed string
+        (1234567890, "must be a datetime object or a string"),  # Integer
+    ]
+
+    for value, error_match in test_cases:
+        with pytest.raises(ValueError, match=error_match):
+            message.message_origin_date_utc = value
+
+
+def test_serialization_exclusions(phone_number_model: PhoneNumberModel):
+    """Test that private attributes are excluded from serialization."""
+    message = UserDetailsUpdateMessage(
+        patron="patron_123",
+        user_id="user_456",
+        phone_number=phone_number_model,
+    )
+    message.message_origin_date_utc = "2025-04-10T22:15:10.975368Z"
+    
+    serialized = message.model_dump(by_alias=True)
+    private_attrs = ["event_name", "entities", "message_origin_date_utc"]
+    for attr in private_attrs:
+        assert attr not in serialized
+    
+    assert set(serialized.keys()) == {"user_id", "phone_number"}
+    assert serialized["user_id"] == "user_456"
+    assert serialized["phone_number"] == {"number": 700000, "country_code": 48}


### PR DESCRIPTION
- Bumped version to 0.1.4
- Added possibility to define `message_origin_date_utc` in the StellaNowMessageBase with validation
- Introduced UUID validation for `organization_id` and `project_id`
- Fixed bug related to not executing `refresh_token` in OIDC, causing reauthentication
- Added helper methods for PROD environment
- Adjusted test cases for Wrapper
