### PR TITLE
[STLND-2398] Update in the auth_service and mqqt_sink

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stellanow-sdk-python"
-version = "0.1.5"
+version = "0.1.6"
 description = "Welcome to the StellaNow Python SDK. This SDK is designed to provide an easy-to-use interface for developers integrating their Python applications with the StellaNow Platform. The SDK communicates with the StellaNow Platform using the MQTT."
 authors = [
     {name = "Stella Systems",email = "help@stella.systems"}

--- a/stellanow_sdk_python/authentication/auth_service.py
+++ b/stellanow_sdk_python/authentication/auth_service.py
@@ -87,13 +87,18 @@ class StellaNowAuthenticationService:
         3. Refreshes the token using the refresh_token
         4. Falls back to full re-authentication if refresh token is expired
         5. Notifies registered callbacks of the new token
-        6. Retries with exponential backoff on transient failures (network errors)
+        6. Retries with adaptive backoff based on error type:
+           - Server errors (503/502): 5-10 second backoff (aggressive retry)
+           - Network errors: 1-30 second backoff (moderate retry)
+           - Other errors: 1-60 second backoff (conservative retry)
 
         If no valid token exists, it will retry authentication every second.
         This ensures the SDK always has a valid token for MQTT authentication.
         """
-        retry_delay = 1  # Initial retry delay for transient errors
-        max_retry_delay = 60  # Cap at 60 seconds
+        retry_delay = 1
+        max_retry_delay = 60
+        server_error_max_delay = 10
+        network_error_max_delay = 30
 
         while True:
             if self.token_response and self.token_expires and not self._is_token_expired():
@@ -108,25 +113,31 @@ class StellaNowAuthenticationService:
 
             try:
                 await self.refresh_access_token()
-                # Reset retry delay on success
                 retry_delay = 1
+                logger.debug("Token refresh successful, retry delay reset to 1 second")
             except TokenRefreshError as e:
-                # TokenRefreshError means BOTH refresh and re-auth failed
-                # This is a critical error - likely credential issue or Keycloak down
-                logger.error(f"Critical: Token refresh and re-authentication both failed: {e}")
-                if self._is_token_expired():
+                error_str = str(e).lower()
+                is_server_error = any(code in error_str for code in ["503", "502", "500", "<html"])
+
+                if is_server_error:
+                    logger.warning(
+                        f"Server error detected (503/502/500). Keycloak may be temporarily down. "
+                        f"Retrying aggressively with {min(retry_delay, server_error_max_delay)}s delay."
+                    )
+                    await asyncio.sleep(min(retry_delay, server_error_max_delay))
+                    retry_delay = min(retry_delay * 2, server_error_max_delay)
+                elif self._is_token_expired():
                     logger.warning("Token is expired, retrying immediately with re-authentication.")
-                    # Reset delay for immediate retry
                     retry_delay = 1
                     continue
-                # Exponential backoff for transient errors
-                await asyncio.sleep(retry_delay)
-                retry_delay = min(retry_delay * 2, max_retry_delay)
+                else:
+                    logger.error(f"Critical: Token refresh and re-authentication both failed: {e}")
+                    await asyncio.sleep(retry_delay)
+                    retry_delay = min(retry_delay * 2, max_retry_delay)
             except (ConnectionError, asyncio.TimeoutError) as e:
-                # Network errors - use exponential backoff
                 logger.error(f"Network error during token refresh: {e}")
-                await asyncio.sleep(retry_delay)
-                retry_delay = min(retry_delay * 2, max_retry_delay)
+                await asyncio.sleep(min(retry_delay, network_error_max_delay))
+                retry_delay = min(retry_delay * 2, network_error_max_delay)
             except (KeycloakError, ValueError) as e:
                 logger.error(f"Unexpected error in auto-refresh: {e}")
                 if self._is_token_expired():
@@ -161,7 +172,6 @@ class StellaNowAuthenticationService:
             logger.error(f"Keycloak authentication failed: {error_status} - {error_message}")
             logger.debug(f"Full Keycloak error details: {e}")
 
-            # Check if this is a permanent error (invalid credentials, etc.)
             if self._is_permanent_auth_error(e):
                 logger.critical(
                     f"Permanent authentication error detected: {error_message}. "
@@ -174,16 +184,42 @@ class StellaNowAuthenticationService:
                     is_permanent=True,
                 ) from None
 
-            # Transient errors (network, server) - raise ValueError for retry
             raise ValueError(f"Failed to authenticate with Keycloak: {error_status} - {error_message}")
         except (ValueError, ConnectionError, asyncio.TimeoutError) as e:
             logger.error(f"Unexpected authentication error: {e}")
             raise ValueError(f"Authentication failed: {e}")
 
     async def authenticate(self) -> str:
-        """Authenticate and get the access token asynchronously."""
+        """
+        Authenticate and get the access token asynchronously.
+
+        Retries up to 2 times on invalid_grant errors to handle race conditions when multiple
+        SDK instances authenticate simultaneously with the same credentials.
+        Uses exponential backoff: 100ms, then 300ms.
+        """
         async with self.lock:
-            return await self._authenticate_internal()
+            max_retries = 2
+            retry_delays = [0.1, 0.3]  # 100ms, 300ms
+
+            for attempt in range(max_retries + 1):
+                try:
+                    return await self._authenticate_internal()
+                except AuthenticationError as e:
+                    if e.error_code == 401 and "invalid_grant" in str(e).lower() and attempt < max_retries:
+                        delay = retry_delays[attempt]
+                        logger.warning(
+                            f"Authentication attempt {attempt + 1} failed with invalid_grant. "
+                            f"This may be due to concurrent authentication from multiple workers. "
+                            f"Retrying after {delay * 1000:.0f}ms delay... (attempt {attempt + 2}/{max_retries + 1})"
+                        )
+                        await asyncio.sleep(delay)
+                        continue
+                    if attempt == max_retries:
+                        logger.error(
+                            f"Authentication failed after {max_retries + 1} attempts. "
+                            f"This is likely a real credential problem, not a race condition."
+                        )
+                    raise
 
     @staticmethod
     def _calculate_token_expires_time(token_response: Dict[str, Any]) -> datetime:
@@ -222,6 +258,28 @@ class StellaNowAuthenticationService:
     def _is_credential_error(self, error_message: str, error_code: Optional[int]) -> bool:
         """Check if error indicates credential/grant issues (permanent auth problem)."""
         return error_code == 401 and ("grant" in error_message or "credential" in error_message)
+
+    def _is_server_error(self, error: KeycloakError) -> bool:
+        """
+        Check if a KeycloakError indicates a transient server error.
+
+        Server errors (5xx) indicate temporary service unavailability and should be
+        retried aggressively with shorter backoff delays.
+
+        Args:
+            error: The KeycloakError exception to check
+
+        Returns:
+            True if the error is a transient server error (5xx), False otherwise
+        """
+        error_code, error_message = self._extract_error_info(error)
+        if self._is_html_response(error_message):
+            return True
+
+        if error_code is not None and 500 <= error_code < 600:
+            return True
+
+        return False
 
     def _is_permanent_auth_error(self, error: KeycloakError) -> bool:
         """
@@ -324,6 +382,17 @@ class StellaNowAuthenticationService:
                 return access_token
             except KeycloakError as e:
                 logger.error(f"Failed to refresh access token: {e}")
+
+                if self._is_server_error(e):
+                    error_code = getattr(e, "response_code", "Unknown")
+                    logger.warning(
+                        f"Server error {error_code} detected during token refresh. "
+                        "Keycloak may be temporarily unavailable. Clearing token state and will retry."
+                    )
+                    self.token_response = None
+                    self.token_expires = None
+                    raise TokenRefreshError(f"Server error during token refresh: {error_code} - {e}") from None
+
                 if self._is_token_expiration_error(e):
                     error_code = getattr(e, "response_code", "Unknown")
                     logger.warning(
@@ -334,6 +403,18 @@ class StellaNowAuthenticationService:
                         self.token_response = None
                         self.token_expires = None
                         return await self._authenticate_internal()
+                    except KeycloakError as auth_error:
+                        if self._is_server_error(auth_error):
+                            logger.warning("Re-authentication failed due to server error. Will retry shortly.")
+                            raise TokenRefreshError(
+                                f"Both token refresh and re-authentication failed due to server errors. "
+                                f"Refresh error: {e}, Auth error: {auth_error}"
+                            ) from None
+                        logger.error(f"Re-authentication also failed: {auth_error}")
+                        raise TokenRefreshError(
+                            f"Both token refresh and re-authentication failed. "
+                            f"Refresh error: {e}, Auth error: {auth_error}"
+                        ) from None
                     except Exception as auth_error:
                         logger.error(f"Re-authentication also failed: {auth_error}")
                         raise TokenRefreshError(

--- a/stellanow_sdk_python/sinks/mqtt/stellanow_mqtt_sink.py
+++ b/stellanow_sdk_python/sinks/mqtt/stellanow_mqtt_sink.py
@@ -51,6 +51,7 @@ class StellaNowMqttSink(IStellaNowSink):
         self.client_id = f"StellaNowSDKPython_{generate(size=10)}"
 
         self._is_connected_event = asyncio.Event()
+        self._auth_recovered_event = asyncio.Event()
         self._shutdown = False
         self._monitor_task: Optional[asyncio.Task[None]] = None
         self._client_lock = asyncio.Lock()  # Protects concurrent access to self.client
@@ -59,10 +60,24 @@ class StellaNowMqttSink(IStellaNowSink):
 
         if isinstance(self.auth_strategy, OidcMqttAuthStrategy):
             self.auth_strategy.set_client_lock(self._client_lock)
+            self.auth_strategy.auth_service.register_token_update_callback(self._on_auth_recovered)
 
         self.client.loop_start()
 
         logger.info(f'SDK Client ID is "{self.client_id}"')
+
+    async def _on_auth_recovered(self, new_token: str) -> None:  # noqa
+        """
+        Callback invoked when auth service successfully refreshes token.
+
+        This signals the connection monitor to attempt immediate reconnection
+        instead of waiting for exponential backoff delay.
+
+        Args:
+            new_token: The newly refreshed access token
+        """
+        logger.info("Auth service recovered - signaling connection monitor for immediate retry")
+        self._auth_recovered_event.set()
 
     def _create_mqtt_client(self) -> mqtt.Client:
         """
@@ -281,8 +296,11 @@ class StellaNowMqttSink(IStellaNowSink):
         2. Create a new MQTT client
         3. Authenticate with the configured strategy
         4. Attempt to connect with exponential backoff on failure
+        5. Listen for auth recovery events to retry immediately
 
         The reconnection attempts have exponential backoff with a maximum delay of 60 seconds.
+        However, if the auth service recovers (successfully refreshes token), the monitor
+        will immediately attempt reconnection instead of waiting for backoff delay.
         """
         logger.info("Started connection monitor")
         attempt = 1
@@ -311,6 +329,7 @@ class StellaNowMqttSink(IStellaNowSink):
                         await asyncio.wait_for(self._is_connected_event.wait(), timeout=5.0)
                         logger.info("Successfully connected to MQTT broker")
                         attempt = 1  # Reset attempt counter on success
+                        self._auth_recovered_event.clear()
                     except AuthenticationError as e:
                         # Permanent authentication error - stop retrying
                         logger.critical(
@@ -334,6 +353,14 @@ class StellaNowMqttSink(IStellaNowSink):
                         self.client = None
                         attempt += 1
                         retry_delay = min(attempt * 10, 60)
-                        logger.info(f"Retrying connection in {retry_delay} seconds...")
-                        await asyncio.sleep(retry_delay)
-            await asyncio.sleep(2.5)
+                        logger.info(f"Waiting {retry_delay}s before retry (or until auth recovers)...")
+
+                        try:
+                            await asyncio.wait_for(self._auth_recovered_event.wait(), timeout=retry_delay)
+                            logger.info("Auth service recovered! Attempting immediate reconnection...")
+                            self._auth_recovered_event.clear()
+                            attempt = 1
+                        except asyncio.TimeoutError:
+                            pass
+            else:
+                await asyncio.sleep(2.5)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,12 +25,54 @@ from uuid import UUID
 
 import pytest
 
+from stellanow_sdk_python.authentication.auth_service import StellaNowAuthenticationService
+from stellanow_sdk_python.config.eniviroment_config.stellanow_env_config import EnvConfig
+from stellanow_sdk_python.config.stellanow_auth_credentials import StellaNowCredentials
+from stellanow_sdk_python.config.stellanow_config import StellaProjectInfo
+
 # Test constants
 TEST_ORG_ID = UUID("12345678-1234-5678-1234-567812345678")
 TEST_PROJECT_ID = UUID("87654321-4321-8765-4321-876543218765")
 TEST_CLIENT_ID = "test-client"
 TEST_USERNAME = "test-user"
 TEST_PASSWORD = "test-pass"
+
+
+@pytest.fixture
+def create_auth_service():
+    """Factory fixture for creating auth service instances.
+
+    Returns a factory function that creates StellaNowAuthenticationService instances
+    with standard test configuration. Use this to avoid duplicating auth service
+    creation logic across test files.
+
+    Usage:
+        def test_something(create_auth_service):
+            auth_service = create_auth_service()
+            # ... test code
+    """
+    def _create() -> StellaNowAuthenticationService:
+        project_info = StellaProjectInfo(organization_id=TEST_ORG_ID, project_id=TEST_PROJECT_ID)
+        credentials = StellaNowCredentials(client_id=TEST_CLIENT_ID, username=TEST_USERNAME, password=TEST_PASSWORD)
+        env_config = EnvConfig.stellanow_dev()
+        return StellaNowAuthenticationService(project_info=project_info, credentials=credentials, env_config=env_config)
+    return _create
+
+
+@pytest.fixture
+def create_token_response():
+    """Factory fixture for creating token response dictionaries.
+
+    Returns a factory function that creates standard Keycloak token response dicts.
+
+    Usage:
+        def test_something(create_token_response):
+            token = create_token_response("my_token", "my_refresh", expires_in=600)
+            # ... test code
+    """
+    def _create(access_token: str = "test_token", refresh_token: str = "test_refresh", expires_in: int = 300):
+        return {"access_token": access_token, "refresh_token": refresh_token, "expires_in": expires_in}
+    return _create
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_concurrent_auth_retry.py
+++ b/tests/test_concurrent_auth_retry.py
@@ -1,0 +1,193 @@
+"""Test retry logic for concurrent authentication scenarios (numWorkers > 1)."""
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+from keycloak.exceptions import KeycloakError
+
+from stellanow_sdk_python.authentication.auth_service import StellaNowAuthenticationService
+from stellanow_sdk_python.authentication.exceptions import AuthenticationError
+from stellanow_sdk_python.config.eniviroment_config.stellanow_env_config import EnvConfig
+from stellanow_sdk_python.config.stellanow_auth_credentials import StellaNowCredentials
+from stellanow_sdk_python.config.stellanow_config import StellaProjectInfo
+from tests.conftest import TEST_CLIENT_ID, TEST_ORG_ID, TEST_PASSWORD, TEST_PROJECT_ID, TEST_USERNAME
+
+
+def create_auth_service() -> StellaNowAuthenticationService:
+    """Create a test authentication service instance."""
+    project_info = StellaProjectInfo(organization_id=TEST_ORG_ID, project_id=TEST_PROJECT_ID)
+    credentials = StellaNowCredentials(client_id=TEST_CLIENT_ID, username=TEST_USERNAME, password=TEST_PASSWORD)
+    env_config = EnvConfig.stellanow_dev()
+    return StellaNowAuthenticationService(project_info=project_info, credentials=credentials, env_config=env_config)
+
+
+def create_token_response(access_token: str = "test_token", refresh_token: str = "test_refresh", expires_in: int = 300):
+    """Create a standard token response dictionary."""
+    return {"access_token": access_token, "refresh_token": refresh_token, "expires_in": expires_in}
+
+
+@pytest.mark.asyncio
+class TestConcurrentAuthenticationRetry:
+    """Test authentication retry logic for race conditions during concurrent authentication."""
+
+    async def test_invalid_grant_retries_once_and_succeeds(self):
+        """
+        Test that invalid_grant error during initial auth triggers a retry that succeeds.
+
+        This simulates the numWorkers:2 scenario where one worker gets invalid_grant
+        due to concurrent authentication, but retry succeeds.
+        """
+        auth_service = create_auth_service()
+
+        # Mock: First call fails with invalid_grant, second succeeds
+        invalid_grant_error = KeycloakError(
+            error_message='{"error":"invalid_grant","error_description":"Invalid user credentials"}',
+            response_code=401
+        )
+        success_token = create_token_response("successful_token", "refresh_token")
+
+        call_count = 0
+
+        async def mock_token_with_retry(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise invalid_grant_error
+            return success_token
+
+        auth_service.keycloak_openid.a_token = AsyncMock(side_effect=mock_token_with_retry)
+
+        # Execute: should retry and succeed
+        result = await auth_service.authenticate()
+
+        # Verify: got token after retry
+        assert result == "successful_token"
+        assert call_count == 2  # Called twice (initial + retry)
+        assert auth_service.token_response == success_token
+
+    async def test_invalid_grant_retries_then_fails(self):
+        """
+        Test that invalid_grant error that persists after retries raises AuthenticationError.
+
+        This ensures we don't endlessly retry real credential problems.
+        """
+        auth_service = create_auth_service()
+
+        # Mock: All attempts fail with invalid_grant (real credential problem)
+        invalid_grant_error = KeycloakError(
+            error_message='{"error":"invalid_grant","error_description":"Invalid user credentials"}',
+            response_code=401
+        )
+
+        auth_service.keycloak_openid.a_token = AsyncMock(side_effect=invalid_grant_error)
+
+        # Execute & Verify: should raise AuthenticationError after all retries
+        with pytest.raises(AuthenticationError) as exc_info:
+            await auth_service.authenticate()
+
+        assert "invalid_grant" in str(exc_info.value).lower()
+        assert auth_service.keycloak_openid.a_token.call_count == 3  # Initial + 2 retries
+
+    async def test_other_401_errors_not_retried(self):
+        """
+        Test that 401 errors that are NOT invalid_grant are not retried.
+
+        Only invalid_grant should trigger retry (it can be transient in concurrent scenarios).
+        """
+        auth_service = create_auth_service()
+
+        # Mock: Account locked error (permanent, should not retry)
+        locked_error = KeycloakError(
+            error_message='{"error":"account_locked","error_description":"Account is locked"}',
+            response_code=401
+        )
+
+        auth_service.keycloak_openid.a_token = AsyncMock(side_effect=locked_error)
+
+        # Execute & Verify: should raise immediately without retry
+        with pytest.raises(AuthenticationError):
+            await auth_service.authenticate()
+
+        assert auth_service.keycloak_openid.a_token.call_count == 1  # No retry
+
+    async def test_two_workers_concurrent_auth_with_retry(self):
+        """
+        Test realistic numWorkers:2 scenario where one worker gets invalid_grant.
+
+        Simulates:
+        - Worker 1 and Worker 2 authenticate simultaneously
+        - Worker 1 gets invalid_grant (race condition), retries, succeeds
+        - Worker 2 succeeds immediately
+        - Both end up authenticated successfully
+        """
+        worker_1_auth = create_auth_service()
+        worker_2_auth = create_auth_service()
+
+        # Worker 1: fails first, succeeds on retry
+        invalid_grant_error = KeycloakError(
+            error_message='{"error":"invalid_grant"}',
+            response_code=401
+        )
+        worker_1_success_token = create_token_response("worker_1_token", "worker_1_refresh")
+
+        worker_1_call_count = 0
+
+        async def worker_1_mock(*args, **kwargs):
+            nonlocal worker_1_call_count
+            worker_1_call_count += 1
+            if worker_1_call_count == 1:
+                raise invalid_grant_error
+            return worker_1_success_token
+
+        worker_1_auth.keycloak_openid.a_token = AsyncMock(side_effect=worker_1_mock)
+
+        # Worker 2: succeeds immediately
+        worker_2_token = create_token_response("worker_2_token", "worker_2_refresh")
+        worker_2_auth.keycloak_openid.a_token = AsyncMock(return_value=worker_2_token)
+
+        # Execute: both authenticate concurrently
+        results = await asyncio.gather(
+            worker_1_auth.authenticate(),
+            worker_2_auth.authenticate()
+        )
+
+        # Verify: both succeeded
+        assert results[0] == "worker_1_token"
+        assert results[1] == "worker_2_token"
+        assert worker_1_call_count == 2  # Worker 1 retried
+        assert worker_2_auth.keycloak_openid.a_token.call_count == 1  # Worker 2 succeeded first try
+
+    async def test_retry_delay_desynchronizes_workers(self):
+        """
+        Test that the 100ms retry delay helps desynchronize workers.
+
+        The retry delay ensures that if both workers initially conflict,
+        the retry won't happen at exactly the same time.
+        """
+        auth_service = create_auth_service()
+
+        invalid_grant_error = KeycloakError(
+            error_message='{"error":"invalid_grant"}',
+            response_code=401
+        )
+        success_token = create_token_response()
+
+        call_times = []
+
+        async def mock_token_with_timing(*args, **kwargs):
+            call_times.append(asyncio.get_event_loop().time())
+            if len(call_times) == 1:
+                raise invalid_grant_error
+            return success_token
+
+        auth_service.keycloak_openid.a_token = AsyncMock(side_effect=mock_token_with_timing)
+
+        # Execute
+        await auth_service.authenticate()
+
+        # Verify: retry happened at least 100ms after initial attempt
+        assert len(call_times) == 2
+        time_between_calls = (call_times[1] - call_times[0]) * 1000  # Convert to ms
+        assert time_between_calls >= 100  # At least 100ms delay
+        assert time_between_calls < 200  # But not too long (should be ~100ms)

--- a/tests/test_concurrent_auth_retry.py
+++ b/tests/test_concurrent_auth_retry.py
@@ -6,32 +6,14 @@ from unittest.mock import AsyncMock
 import pytest
 from keycloak.exceptions import KeycloakError
 
-from stellanow_sdk_python.authentication.auth_service import StellaNowAuthenticationService
 from stellanow_sdk_python.authentication.exceptions import AuthenticationError
-from stellanow_sdk_python.config.eniviroment_config.stellanow_env_config import EnvConfig
-from stellanow_sdk_python.config.stellanow_auth_credentials import StellaNowCredentials
-from stellanow_sdk_python.config.stellanow_config import StellaProjectInfo
-from tests.conftest import TEST_CLIENT_ID, TEST_ORG_ID, TEST_PASSWORD, TEST_PROJECT_ID, TEST_USERNAME
-
-
-def create_auth_service() -> StellaNowAuthenticationService:
-    """Create a test authentication service instance."""
-    project_info = StellaProjectInfo(organization_id=TEST_ORG_ID, project_id=TEST_PROJECT_ID)
-    credentials = StellaNowCredentials(client_id=TEST_CLIENT_ID, username=TEST_USERNAME, password=TEST_PASSWORD)
-    env_config = EnvConfig.stellanow_dev()
-    return StellaNowAuthenticationService(project_info=project_info, credentials=credentials, env_config=env_config)
-
-
-def create_token_response(access_token: str = "test_token", refresh_token: str = "test_refresh", expires_in: int = 300):
-    """Create a standard token response dictionary."""
-    return {"access_token": access_token, "refresh_token": refresh_token, "expires_in": expires_in}
 
 
 @pytest.mark.asyncio
 class TestConcurrentAuthenticationRetry:
     """Test authentication retry logic for race conditions during concurrent authentication."""
 
-    async def test_invalid_grant_retries_once_and_succeeds(self):
+    async def test_invalid_grant_retries_once_and_succeeds(self, create_auth_service, create_token_response):
         """
         Test that invalid_grant error during initial auth triggers a retry that succeeds.
 
@@ -66,7 +48,7 @@ class TestConcurrentAuthenticationRetry:
         assert call_count == 2  # Called twice (initial + retry)
         assert auth_service.token_response == success_token
 
-    async def test_invalid_grant_retries_then_fails(self):
+    async def test_invalid_grant_retries_then_fails(self, create_auth_service):
         """
         Test that invalid_grant error that persists after retries raises AuthenticationError.
 
@@ -89,7 +71,7 @@ class TestConcurrentAuthenticationRetry:
         assert "invalid_grant" in str(exc_info.value).lower()
         assert auth_service.keycloak_openid.a_token.call_count == 3  # Initial + 2 retries
 
-    async def test_other_401_errors_not_retried(self):
+    async def test_other_401_errors_not_retried(self, create_auth_service):
         """
         Test that 401 errors that are NOT invalid_grant are not retried.
 
@@ -111,7 +93,7 @@ class TestConcurrentAuthenticationRetry:
 
         assert auth_service.keycloak_openid.a_token.call_count == 1  # No retry
 
-    async def test_two_workers_concurrent_auth_with_retry(self):
+    async def test_two_workers_concurrent_auth_with_retry(self, create_auth_service, create_token_response):
         """
         Test realistic numWorkers:2 scenario where one worker gets invalid_grant.
 
@@ -158,7 +140,7 @@ class TestConcurrentAuthenticationRetry:
         assert worker_1_call_count == 2  # Worker 1 retried
         assert worker_2_auth.keycloak_openid.a_token.call_count == 1  # Worker 2 succeeded first try
 
-    async def test_retry_delay_desynchronizes_workers(self):
+    async def test_retry_delay_desynchronizes_workers(self, create_auth_service, create_token_response):
         """
         Test that the 100ms retry delay helps desynchronize workers.
 

--- a/tests/test_connection_handling.py
+++ b/tests/test_connection_handling.py
@@ -263,7 +263,7 @@ class TestTokenRefreshRuntimeCheck:
                 side_effect=KeycloakError("Refresh failed", response_code=500)
             )
 
-            with pytest.raises(TokenRefreshError, match="Failed to refresh access token"):
+            with pytest.raises(TokenRefreshError, match="Server error during token refresh"):
                 await auth_service.refresh_access_token()
         finally:
             # Cleanup: stop any background refresh task that might have started

--- a/tests/test_multi_instance_auth.py
+++ b/tests/test_multi_instance_auth.py
@@ -2,36 +2,17 @@
 
 import asyncio
 from datetime import datetime, timedelta
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock
 
 import pytest
 from keycloak.exceptions import KeycloakError
-
-from stellanow_sdk_python.authentication.auth_service import StellaNowAuthenticationService
-from stellanow_sdk_python.config.eniviroment_config.stellanow_env_config import EnvConfig
-from stellanow_sdk_python.config.stellanow_auth_credentials import StellaNowCredentials
-from stellanow_sdk_python.config.stellanow_config import StellaProjectInfo
-from tests.conftest import TEST_CLIENT_ID, TEST_ORG_ID, TEST_PASSWORD, TEST_PROJECT_ID, TEST_USERNAME
-
-
-def create_auth_service() -> StellaNowAuthenticationService:
-    """Create a test authentication service instance."""
-    project_info = StellaProjectInfo(organization_id=TEST_ORG_ID, project_id=TEST_PROJECT_ID)
-    credentials = StellaNowCredentials(client_id=TEST_CLIENT_ID, username=TEST_USERNAME, password=TEST_PASSWORD)
-    env_config = EnvConfig.stellanow_dev()
-    return StellaNowAuthenticationService(project_info=project_info, credentials=credentials, env_config=env_config)
-
-
-def create_token_response(access_token: str = "test_token", refresh_token: str = "test_refresh", expires_in: int = 300):
-    """Create a standard token response dictionary."""
-    return {"access_token": access_token, "refresh_token": refresh_token, "expires_in": expires_in}
 
 
 @pytest.mark.asyncio
 class TestMultiInstanceAuthentication:
     """Test authentication with multiple SDK instances (simulating Nuclio numWorkers: 2)."""
 
-    async def test_two_instances_authenticate_independently(self):
+    async def test_two_instances_authenticate_independently(self, create_auth_service, create_token_response):
         """Test that two SDK instances can authenticate independently without conflicts."""
         # Create two separate auth service instances (like two Nuclio workers)
         auth_service_1 = create_auth_service()
@@ -56,7 +37,7 @@ class TestMultiInstanceAuthentication:
         assert auth_service_1.token_response["access_token"] == "token_worker_1"
         assert auth_service_2.token_response["access_token"] == "token_worker_2"
 
-    async def test_two_instances_with_same_credentials_no_deadlock(self):
+    async def test_two_instances_with_same_credentials_no_deadlock(self, create_auth_service, create_token_response):
         """Test that two instances using same credentials don't deadlock during authentication."""
         auth_service_1 = create_auth_service()
         auth_service_2 = create_auth_service()
@@ -94,7 +75,7 @@ class TestMultiInstanceAuthentication:
         except asyncio.TimeoutError:
             pytest.fail("Authentication deadlocked with two instances - CONFIRMED BUG!")
 
-    async def test_two_instances_refresh_tokens_simultaneously(self):
+    async def test_two_instances_refresh_tokens_simultaneously(self, create_auth_service, create_token_response):
         """Test that two instances can refresh tokens simultaneously without conflicts."""
         auth_service_1 = create_auth_service()
         auth_service_2 = create_auth_service()
@@ -124,7 +105,7 @@ class TestMultiInstanceAuthentication:
         assert auth_service_1.token_response["access_token"] == "new_token_1"
         assert auth_service_2.token_response["access_token"] == "new_token_2"
 
-    async def test_two_instances_one_fails_other_succeeds(self):
+    async def test_two_instances_one_fails_other_succeeds(self, create_auth_service, create_token_response):
         """Test that one instance failing doesn't affect the other instance."""
         auth_service_1 = create_auth_service()
         auth_service_2 = create_auth_service()
@@ -148,7 +129,7 @@ class TestMultiInstanceAuthentication:
         assert results[1] == "token_worker_2"
         assert auth_service_2.token_response["access_token"] == "token_worker_2"
 
-    async def test_shared_lock_doesnt_exist_between_instances(self):
+    async def test_shared_lock_doesnt_exist_between_instances(self, create_auth_service):
         """Verify that each instance has its own lock (not shared)."""
         auth_service_1 = create_auth_service()
         auth_service_2 = create_auth_service()
@@ -157,7 +138,7 @@ class TestMultiInstanceAuthentication:
         assert auth_service_1.lock is not auth_service_2.lock
         assert id(auth_service_1.lock) != id(auth_service_2.lock)
 
-    async def test_nuclio_scenario_two_workers_init_context(self):
+    async def test_nuclio_scenario_two_workers_init_context(self, create_auth_service, create_token_response):
         """
         Simulate the actual Nuclio scenario:
         - Two workers (separate Python processes in reality, but we simulate with asyncio)

--- a/tests/test_multi_instance_auth.py
+++ b/tests/test_multi_instance_auth.py
@@ -1,0 +1,213 @@
+"""Test authentication behavior with multiple SDK instances (simulating Nuclio multi-worker scenario)."""
+
+import asyncio
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from keycloak.exceptions import KeycloakError
+
+from stellanow_sdk_python.authentication.auth_service import StellaNowAuthenticationService
+from stellanow_sdk_python.config.eniviroment_config.stellanow_env_config import EnvConfig
+from stellanow_sdk_python.config.stellanow_auth_credentials import StellaNowCredentials
+from stellanow_sdk_python.config.stellanow_config import StellaProjectInfo
+from tests.conftest import TEST_CLIENT_ID, TEST_ORG_ID, TEST_PASSWORD, TEST_PROJECT_ID, TEST_USERNAME
+
+
+def create_auth_service() -> StellaNowAuthenticationService:
+    """Create a test authentication service instance."""
+    project_info = StellaProjectInfo(organization_id=TEST_ORG_ID, project_id=TEST_PROJECT_ID)
+    credentials = StellaNowCredentials(client_id=TEST_CLIENT_ID, username=TEST_USERNAME, password=TEST_PASSWORD)
+    env_config = EnvConfig.stellanow_dev()
+    return StellaNowAuthenticationService(project_info=project_info, credentials=credentials, env_config=env_config)
+
+
+def create_token_response(access_token: str = "test_token", refresh_token: str = "test_refresh", expires_in: int = 300):
+    """Create a standard token response dictionary."""
+    return {"access_token": access_token, "refresh_token": refresh_token, "expires_in": expires_in}
+
+
+@pytest.mark.asyncio
+class TestMultiInstanceAuthentication:
+    """Test authentication with multiple SDK instances (simulating Nuclio numWorkers: 2)."""
+
+    async def test_two_instances_authenticate_independently(self):
+        """Test that two SDK instances can authenticate independently without conflicts."""
+        # Create two separate auth service instances (like two Nuclio workers)
+        auth_service_1 = create_auth_service()
+        auth_service_2 = create_auth_service()
+
+        # Mock Keycloak responses for both instances
+        token_1 = create_token_response("token_worker_1", "refresh_worker_1")
+        token_2 = create_token_response("token_worker_2", "refresh_worker_2")
+
+        auth_service_1.keycloak_openid.a_token = AsyncMock(return_value=token_1)
+        auth_service_2.keycloak_openid.a_token = AsyncMock(return_value=token_2)
+
+        # Authenticate both simultaneously (like Nuclio workers starting)
+        results = await asyncio.gather(
+            auth_service_1.authenticate(),
+            auth_service_2.authenticate()
+        )
+
+        # Verify: both succeeded with their own tokens
+        assert results[0] == "token_worker_1"
+        assert results[1] == "token_worker_2"
+        assert auth_service_1.token_response["access_token"] == "token_worker_1"
+        assert auth_service_2.token_response["access_token"] == "token_worker_2"
+
+    async def test_two_instances_with_same_credentials_no_deadlock(self):
+        """Test that two instances using same credentials don't deadlock during authentication."""
+        auth_service_1 = create_auth_service()
+        auth_service_2 = create_auth_service()
+
+        # Shared call counter to verify both instances complete
+        call_count = 0
+        call_lock = asyncio.Lock()
+
+        async def mock_token_with_delay(*args, **kwargs):
+            """Mock token call with delay to simulate network latency."""
+            nonlocal call_count
+            await asyncio.sleep(0.1)  # Simulate network delay
+            async with call_lock:
+                call_count += 1
+            return create_token_response(f"token_{call_count}", f"refresh_{call_count}")
+
+        auth_service_1.keycloak_openid.a_token = AsyncMock(side_effect=mock_token_with_delay)
+        auth_service_2.keycloak_openid.a_token = AsyncMock(side_effect=mock_token_with_delay)
+
+        # Start authentication simultaneously with timeout
+        try:
+            results = await asyncio.wait_for(
+                asyncio.gather(
+                    auth_service_1.authenticate(),
+                    auth_service_2.authenticate()
+                ),
+                timeout=5.0  # Should complete within 5 seconds
+            )
+
+            # Verify: both completed successfully
+            assert len(results) == 2
+            assert call_count == 2
+            assert auth_service_1.token_response is not None
+            assert auth_service_2.token_response is not None
+        except asyncio.TimeoutError:
+            pytest.fail("Authentication deadlocked with two instances - CONFIRMED BUG!")
+
+    async def test_two_instances_refresh_tokens_simultaneously(self):
+        """Test that two instances can refresh tokens simultaneously without conflicts."""
+        auth_service_1 = create_auth_service()
+        auth_service_2 = create_auth_service()
+
+        # Setup: both have valid tokens
+        auth_service_1.token_response = create_token_response("token_1", "refresh_1")
+        auth_service_1.token_expires = datetime.now() + timedelta(seconds=300)
+        auth_service_2.token_response = create_token_response("token_2", "refresh_2")
+        auth_service_2.token_expires = datetime.now() + timedelta(seconds=300)
+
+        # Mock refresh responses
+        new_token_1 = create_token_response("new_token_1", "new_refresh_1")
+        new_token_2 = create_token_response("new_token_2", "new_refresh_2")
+
+        auth_service_1.keycloak_openid.a_refresh_token = AsyncMock(return_value=new_token_1)
+        auth_service_2.keycloak_openid.a_refresh_token = AsyncMock(return_value=new_token_2)
+
+        # Refresh both simultaneously
+        results = await asyncio.gather(
+            auth_service_1.refresh_access_token(),
+            auth_service_2.refresh_access_token()
+        )
+
+        # Verify: both refreshed successfully with their own tokens
+        assert results[0] == "new_token_1"
+        assert results[1] == "new_token_2"
+        assert auth_service_1.token_response["access_token"] == "new_token_1"
+        assert auth_service_2.token_response["access_token"] == "new_token_2"
+
+    async def test_two_instances_one_fails_other_succeeds(self):
+        """Test that one instance failing doesn't affect the other instance."""
+        auth_service_1 = create_auth_service()
+        auth_service_2 = create_auth_service()
+
+        # Mock: first instance fails, second succeeds
+        auth_error = KeycloakError(error_message="Invalid credentials", response_code=401)
+        auth_service_1.keycloak_openid.a_token = AsyncMock(side_effect=auth_error)
+
+        success_token = create_token_response("token_worker_2", "refresh_worker_2")
+        auth_service_2.keycloak_openid.a_token = AsyncMock(return_value=success_token)
+
+        # Try to authenticate both
+        results = await asyncio.gather(
+            auth_service_1.authenticate(),
+            auth_service_2.authenticate(),
+            return_exceptions=True
+        )
+
+        # Verify: first failed, second succeeded
+        assert isinstance(results[0], Exception)
+        assert results[1] == "token_worker_2"
+        assert auth_service_2.token_response["access_token"] == "token_worker_2"
+
+    async def test_shared_lock_doesnt_exist_between_instances(self):
+        """Verify that each instance has its own lock (not shared)."""
+        auth_service_1 = create_auth_service()
+        auth_service_2 = create_auth_service()
+
+        # Verify: different lock objects
+        assert auth_service_1.lock is not auth_service_2.lock
+        assert id(auth_service_1.lock) != id(auth_service_2.lock)
+
+    async def test_nuclio_scenario_two_workers_init_context(self):
+        """
+        Simulate the actual Nuclio scenario:
+        - Two workers (separate Python processes in reality, but we simulate with asyncio)
+        - Each calls init_context() which creates SDK and calls await sdk.start()
+        - SDK start() calls auth_service.authenticate()
+
+        This tests if there's any deadlock or race condition.
+        """
+        # Simulate two Nuclio workers
+        worker_1_auth = create_auth_service()
+        worker_2_auth = create_auth_service()
+
+        # Mock Keycloak with realistic delay
+        call_order = []
+
+        def create_mock_auth(worker_id):
+            """Create a mock auth function for a specific worker."""
+            async def mock_auth(*args, **kwargs):
+                call_order.append(f"{worker_id}_start")
+                await asyncio.sleep(0.1)  # Simulate network latency
+                call_order.append(f"{worker_id}_end")
+                return create_token_response(f"token_{worker_id}", f"refresh_{worker_id}")
+            return mock_auth
+
+        worker_1_auth.keycloak_openid.a_token = AsyncMock(side_effect=create_mock_auth("worker_1"))
+        worker_2_auth.keycloak_openid.a_token = AsyncMock(side_effect=create_mock_auth("worker_2"))
+
+        # Simulate init_context() being called on both workers simultaneously
+        try:
+            await asyncio.wait_for(
+                asyncio.gather(
+                    worker_1_auth.authenticate(),
+                    worker_2_auth.authenticate()
+                ),
+                timeout=5.0
+            )
+
+            # Verify: both completed without deadlock
+            assert len(call_order) == 4
+            assert "worker_1_start" in call_order
+            assert "worker_1_end" in call_order
+            assert "worker_2_start" in call_order
+            assert "worker_2_end" in call_order
+
+            # Verify: both have valid tokens
+            assert worker_1_auth.token_response is not None
+            assert worker_2_auth.token_response is not None
+        except asyncio.TimeoutError:
+            pytest.fail(
+                f"DEADLOCK DETECTED in Nuclio scenario! "
+                f"Call order: {call_order}. "
+                f"This confirms the bug reported in the analysis."
+            )

--- a/tests/test_token_refresh_recovery.py
+++ b/tests/test_token_refresh_recovery.py
@@ -9,26 +9,9 @@ from keycloak.exceptions import KeycloakError
 
 from stellanow_sdk_python.authentication.auth_service import StellaNowAuthenticationService
 from stellanow_sdk_python.authentication.exceptions import TokenRefreshError
-from stellanow_sdk_python.config.eniviroment_config.stellanow_env_config import EnvConfig
-from stellanow_sdk_python.config.stellanow_auth_credentials import StellaNowCredentials
-from stellanow_sdk_python.config.stellanow_config import StellaProjectInfo
-from tests.conftest import TEST_CLIENT_ID, TEST_ORG_ID, TEST_PASSWORD, TEST_PROJECT_ID, TEST_USERNAME
 
 
-# Helper functions
-def create_auth_service() -> StellaNowAuthenticationService:
-    """Create a test authentication service instance with standard test data."""
-    project_info = StellaProjectInfo(organization_id=TEST_ORG_ID, project_id=TEST_PROJECT_ID)
-    credentials = StellaNowCredentials(client_id=TEST_CLIENT_ID, username=TEST_USERNAME, password=TEST_PASSWORD)
-    env_config = EnvConfig.stellanow_dev()
-    return StellaNowAuthenticationService(project_info=project_info, credentials=credentials, env_config=env_config)
-
-
-def create_token_response(access_token: str = "test_token", refresh_token: str = "test_refresh", expires_in: int = 300):
-    """Create a standard token response dictionary."""
-    return {"access_token": access_token, "refresh_token": refresh_token, "expires_in": expires_in}
-
-
+# Helper function
 def setup_auth_service_with_token(auth_service: StellaNowAuthenticationService, token_response: dict) -> None:
     """Set up auth service with existing token response."""
     auth_service.token_response = token_response
@@ -38,7 +21,7 @@ def setup_auth_service_with_token(auth_service: StellaNowAuthenticationService, 
 class TestPermanentAuthErrorDetection:
     """Test _is_permanent_auth_error helper method."""
 
-    def test_detects_invalid_credentials(self):
+    def test_detects_invalid_credentials(self, create_auth_service):
         """Test that invalid credentials errors are detected as permanent using generic patterns."""
         auth_service = create_auth_service()
 
@@ -59,7 +42,7 @@ class TestPermanentAuthErrorDetection:
             error = KeycloakError(error_message=error_msg, response_code=error_code)
             assert auth_service._is_permanent_auth_error(error) is expected, description
 
-    def test_html_responses_are_not_permanent(self):
+    def test_html_responses_are_not_permanent(self, create_auth_service):
         """Test that HTML responses (proxy/firewall errors) are NOT permanent."""
         auth_service = create_auth_service()
 
@@ -73,7 +56,7 @@ class TestPermanentAuthErrorDetection:
             error = KeycloakError(error_message=error_msg, response_code=error_code)
             assert auth_service._is_permanent_auth_error(error) is False, f"{description} should NOT be permanent"
 
-    def test_json_403_is_permanent(self):
+    def test_json_403_is_permanent(self, create_auth_service):
         """Test that JSON 403 errors (actual authorization issues) are permanent."""
         auth_service = create_auth_service()
 
@@ -90,7 +73,7 @@ class TestPermanentAuthErrorDetection:
 class TestTokenExpirationErrorDetection:
     """Test _is_token_expiration_error helper method."""
 
-    def test_detects_http_error_codes(self):
+    def test_detects_http_error_codes(self, create_auth_service):
         """Test that HTTP 400 and 401 are detected as token expiration errors."""
         auth_service = create_auth_service()
 
@@ -105,7 +88,7 @@ class TestTokenExpirationErrorDetection:
             error = KeycloakError(error_message=error_msg, response_code=error_code)
             assert auth_service._is_token_expiration_error(error) is expected, description
 
-    def test_detects_generic_token_patterns(self):
+    def test_detects_generic_token_patterns(self, create_auth_service):
         """Test that generic token expiration patterns are detected (Keycloak version-independent)."""
         auth_service = create_auth_service()
 
@@ -140,7 +123,7 @@ class TestTokenExpirationErrorDetection:
 class TestRefreshTokenRecovery:
     """Test refresh_access_token recovery from expired tokens."""
 
-    async def test_expired_token_triggers_reauthentication(self):
+    async def test_expired_token_triggers_reauthentication(self, create_auth_service, create_token_response):
         """Test that expired refresh token (HTTP 400/401) triggers full re-authentication."""
         auth_service = create_auth_service()
 
@@ -172,7 +155,7 @@ class TestRefreshTokenRecovery:
             assert auth_service.token_response == new_token
             assert auth_service.keycloak_openid.a_token.called
 
-    async def test_network_error_raises_token_refresh_error(self):
+    async def test_network_error_raises_token_refresh_error(self, create_auth_service, create_token_response):
         """Test that non-expiration errors (network, server) raise TokenRefreshError."""
         auth_service = create_auth_service()
 
@@ -189,7 +172,7 @@ class TestRefreshTokenRecovery:
 
         assert "Server error during token refresh" in str(exc_info.value)
 
-    async def test_both_refresh_and_reauth_fail(self):
+    async def test_both_refresh_and_reauth_fail(self, create_auth_service, create_token_response):
         """Test that TokenRefreshError is raised when both refresh and re-authentication fail."""
         auth_service = create_auth_service()
 
@@ -211,7 +194,7 @@ class TestRefreshTokenRecovery:
         error_message = str(exc_info.value)
         assert "Both token refresh and re-authentication failed" in error_message
 
-    async def test_old_token_cleared_before_reauthentication(self):
+    async def test_old_token_cleared_before_reauthentication(self, create_auth_service, create_token_response):
         """Test that old token data is cleared before re-authentication attempt."""
         auth_service = create_auth_service()
 
@@ -242,7 +225,7 @@ class TestRefreshTokenRecovery:
 class TestAutoRefreshRecovery:
     """Test _auto_refresh background task recovery behavior."""
 
-    async def test_auto_refresh_recovers_from_expired_token(self):
+    async def test_auto_refresh_recovers_from_expired_token(self, create_auth_service, create_token_response):
         """Test that auto-refresh task automatically recovers when refresh token expires."""
         auth_service = create_auth_service()
 
@@ -278,7 +261,7 @@ class TestAutoRefreshRecovery:
             # Cleanup
             await auth_service.stop_refresh_task()
 
-    async def test_auto_refresh_uses_exponential_backoff(self):
+    async def test_auto_refresh_uses_exponential_backoff(self, create_auth_service, create_token_response):
         """Test that auto-refresh uses exponential backoff on repeated transient errors."""
         auth_service = create_auth_service()
 
@@ -304,7 +287,7 @@ class TestAutoRefreshRecovery:
             # Cleanup
             await auth_service.stop_refresh_task()
 
-    async def test_successful_refresh_resets_backoff_delay(self):
+    async def test_successful_refresh_resets_backoff_delay(self, create_auth_service, create_token_response):
         """Test that successful refresh resets exponential backoff delay."""
         auth_service = create_auth_service()
 

--- a/tests/test_token_refresh_recovery.py
+++ b/tests/test_token_refresh_recovery.py
@@ -187,7 +187,7 @@ class TestRefreshTokenRecovery:
         with pytest.raises(TokenRefreshError) as exc_info:
             await auth_service.refresh_access_token()
 
-        assert "Failed to refresh access token" in str(exc_info.value)
+        assert "Server error during token refresh" in str(exc_info.value)
 
     async def test_both_refresh_and_reauth_fail(self):
         """Test that TokenRefreshError is raised when both refresh and re-authentication fail."""
@@ -312,28 +312,38 @@ class TestAutoRefreshRecovery:
             # Setup: short-lived token
             setup_auth_service_with_token(auth_service, create_token_response(expires_in=1))
 
-            # Mock: first call fails, second succeeds (should reset delay) with SHORT-LIVED token
+            # Mock: first call fails with 500 (server error), second succeeds with SHORT-LIVED token
             success_token = create_token_response("new_token", "new_refresh", expires_in=1)
-            call_count = 0
+            refresh_call_count = 0
+            auth_call_count = 0
 
             async def mock_refresh(token):
-                nonlocal call_count
-                call_count += 1
-                if call_count == 1:
+                nonlocal refresh_call_count
+                refresh_call_count += 1
+                if refresh_call_count == 1:
                     raise KeycloakError(error_message="Timeout", response_code=500)
                 return success_token
 
+            async def mock_auth(*args, **kwargs):
+                # After 500 error, token state is cleared, so re-authentication will be attempted
+                nonlocal auth_call_count
+                auth_call_count += 1
+                return success_token
+
             auth_service.keycloak_openid.a_refresh_token = AsyncMock(side_effect=mock_refresh)
+            auth_service.keycloak_openid.a_token = AsyncMock(side_effect=mock_auth)
 
             # Start refresh task
             await auth_service.start_refresh_task()
 
             # Wait for retry and recovery
+            # After 500 error, token is cleared, so it will attempt re-authentication
             await asyncio.sleep(5)
 
-            # Verify: recovered (called at least twice: once failed, once succeeded)
+            # Verify: recovered (either through refresh or re-authentication)
             assert auth_service.token_response is not None
-            assert call_count >= 2
+            # At least one attempt should have been made (either refresh or re-auth)
+            assert (refresh_call_count + auth_call_count) >= 2
         finally:
             # Cleanup
             await auth_service.stop_refresh_task()


### PR DESCRIPTION
## Ticket

https://stella-systems.atlassian.net/browse/STLND-2398

## Summary

 Added automatic retry logic with exponential backoff to authenticate() method:
  - 1st attempt: Immediate authentication
  - 2nd attempt: Retry after 100ms (handles 2 workers)
  - 3rd attempt: Retry after 300ms (handles 3+ workers)

  Only retries invalid_grant errors during initial authentication (not other 401 errors), preventing endless loops while handling transient race conditions.

## Test Plan

Added/Updated unit tests

## Documentation

Docstrings updated
